### PR TITLE
Change Exception to Warning for duplicate pin use in jig mux.

### DIFF
--- a/src/fixate/core/jig_mapping.py
+++ b/src/fixate/core/jig_mapping.py
@@ -1,7 +1,12 @@
 import time
 import sys
+import warnings
 from math import ceil, log
 from fixate.core.common import bits, deprecated
+
+
+class MuxWarning(Warning):
+    pass
 
 
 class VirtualAddressMap:
@@ -56,8 +61,8 @@ class VirtualAddressMap:
         mux.pin_mask = []
         for itm in mux.pin_list:
             if itm in self.mux_assigned_pins:
-                raise ValueError("Pin {} in {} already assigned in {}".format(itm, mux,
-                                                                              self.mux_assigned_pins[itm]))
+                warnings.warn("Pin {} in {} already assigned in {}".format(itm, mux, self.mux_assigned_pins[itm]),
+                              MuxWarning)
             try:
                 mux.pin_mask.append(self.virtual_pin_list.index(itm))
             except ValueError as e:


### PR DESCRIPTION
Raise exception changed to warnings.warn(MuxWarning). Includes addition of MuxWarning class and warnings import.