### PR TITLE
Revert "Change Exception to Warning for duplicate pin use in jig mux."

### DIFF
--- a/src/fixate/core/jig_mapping.py
+++ b/src/fixate/core/jig_mapping.py
@@ -1,12 +1,7 @@
 import time
 import sys
-import warnings
 from math import ceil, log
 from fixate.core.common import bits, deprecated
-
-
-class MuxWarning(Warning):
-    pass
 
 
 class VirtualAddressMap:
@@ -61,8 +56,8 @@ class VirtualAddressMap:
         mux.pin_mask = []
         for itm in mux.pin_list:
             if itm in self.mux_assigned_pins:
-                warnings.warn("Pin {} in {} already assigned in {}".format(itm, mux, self.mux_assigned_pins[itm]),
-                              MuxWarning)
+                raise ValueError("Pin {} in {} already assigned in {}".format(itm, mux,
+                                                                              self.mux_assigned_pins[itm]))
             try:
                 mux.pin_mask.append(self.virtual_pin_list.index(itm))
             except ValueError as e:


### PR DESCRIPTION
This breaks the build. I missed that the tests hadn't run before merging the PR earlier.
Reverts PyFixate/Fixate#94