### PR TITLE
Warn on duplicate pin use

### DIFF
--- a/src/fixate/core/jig_mapping.py
+++ b/src/fixate/core/jig_mapping.py
@@ -1,7 +1,12 @@
 import time
 import sys
+import warnings
 from math import ceil, log
 from fixate.core.common import bits, deprecated
+
+
+class MuxWarning(Warning):
+    pass
 
 
 class VirtualAddressMap:
@@ -56,8 +61,8 @@ class VirtualAddressMap:
         mux.pin_mask = []
         for itm in mux.pin_list:
             if itm in self.mux_assigned_pins:
-                raise ValueError("Pin {} in {} already assigned in {}".format(itm, mux,
-                                                                              self.mux_assigned_pins[itm]))
+                warnings.warn("Pin {} in {} already assigned in {}".format(itm, mux, self.mux_assigned_pins[itm]),
+                              MuxWarning)
             try:
                 mux.pin_mask.append(self.virtual_pin_list.index(itm))
             except ValueError as e:

--- a/test/core/test_jig_mapping.py
+++ b/test/core/test_jig_mapping.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     import map_data
 
+
 class TestVirtualAddressMap(TestCase):
     """
 


### PR DESCRIPTION
Changed Exception to Warning for pin appearing on multiple mux.
- Add MuxWarning(Warning) class
- Add unittest for a single pin duplicated across two mux
- Modified unittest for duplicated mux to reflect the change to warnings
--> may be unintended consequence, should this still be an exception?