### PR TITLE
Tidy up the test and CI builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,9 @@ jobs:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
-    maxParallel: 2
+      Python38:
+        python.version: '3.8'
+    maxParallel: 3
     
   steps:
     - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,13 +19,11 @@ jobs:
     vmImage: 'VS2017-Win2016'
   strategy:
     matrix:
-      Python35:
-        python.version: '3.5'
       Python36:
         python.version: '3.6'
       Python37:
         python.version: '3.7'
-    maxParallel: 3
+    maxParallel: 2
     
   steps:
     - task: UsePythonVersion@0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-python_classes = 
-testpaths = test

--- a/src/fixate/reporting/csv.py
+++ b/src/fixate/reporting/csv.py
@@ -184,7 +184,7 @@ class CsvReporting:
                 self.test_module.__file__
             ).split(".")[0]
             self.data.update(sequencer.context_data)
-            self.start_time = time.clock()
+            self.start_time = time.perf_counter()
             self._write_line_to_csv(
                 fixate.config.render_template(
                     self.data["tpl_first_line"], **self.data, self=self
@@ -196,7 +196,7 @@ class CsvReporting:
     ):
         self._write_line_to_csv(
             [
-                "{:.2f}".format(time.clock() - self.start_time),
+                "{:.2f}".format(time.perf_counter() - self.start_time),
                 "Sequence",
                 "ended={}".format(
                     self.data["tpl_time_stamp"].format(datetime.datetime.now())
@@ -224,7 +224,7 @@ class CsvReporting:
         # Test <test_index>, start, <test name>
         self._write_line_to_csv(
             [
-                "{:.2f}".format(time.clock() - self.start_time),
+                "{:.2f}".format(time.perf_counter() - self.start_time),
                 "Test {}".format(test_index),
                 "start",
                 data.test_desc,
@@ -237,7 +237,7 @@ class CsvReporting:
         if len(test_params):
             # Test <test_index>, test-parameters, <param_name>=<param_value>, ...
             param_line = [
-                "{:.2f}".format(time.clock() - self.start_time),
+                "{:.2f}".format(time.perf_counter() - self.start_time),
                 "Test {}".format(test_index),
                 "test-parameters",
             ]
@@ -248,7 +248,7 @@ class CsvReporting:
     def test_exception(self, exception, test_index):
         self.current_test = test_index
         exc_line = [
-            "{:.2f}".format(time.clock() - self.start_time),
+            "{:.2f}".format(time.perf_counter() - self.start_time),
             "Test {}".format(test_index),
             "exception",
             re.sub(r",\)", ")", repr(exception)),
@@ -264,7 +264,7 @@ class CsvReporting:
         # Test <test_index>, check<number>, <check type>, <status>, <test_val>, <expected>
         # If exception <test_index>, check<number>, <exception details>
         chk_line = [
-            "{:.2f}".format(time.clock() - self.start_time),
+            "{:.2f}".format(time.perf_counter() - self.start_time),
             "Test {}".format(context),
             "check{}".format(chk_cnt),
             chk.target.__name__[1:].replace("check_", "").replace("_", " "),
@@ -288,7 +288,7 @@ class CsvReporting:
 
             self._write_line_to_csv(
                 [
-                    "{:.2f}".format(time.clock() - self.start_time),
+                    "{:.2f}".format(time.perf_counter() - self.start_time),
                     "Test {}".format(test_index),
                     "end",
                     status,
@@ -302,7 +302,7 @@ class CsvReporting:
     def user_wait_start(self, *args, **kwargs):
         self._write_line_to_csv(
             [
-                "{:.2f}".format(time.clock() - self.start_time),
+                "{:.2f}".format(time.perf_counter() - self.start_time),
                 "Test {}".format(self.current_test),
                 "user_wait_start",
             ]
@@ -311,7 +311,7 @@ class CsvReporting:
     def user_wait_end(self, *args, **kwargs):
         self._write_line_to_csv(
             [
-                "{:.2f}".format(time.clock() - self.start_time),
+                "{:.2f}".format(time.perf_counter() - self.start_time),
                 "Test {}".format(self.current_test),
                 "user_wait_end",
             ]

--- a/test/core/test_deprecated.py
+++ b/test/core/test_deprecated.py
@@ -26,8 +26,8 @@ def test_warning_warn():
 
 def test_returns_functional(mocker):
     test_input = 123
-    with mocker.patch("fixate.core.common.warnings"):
-        assert test_input == mock_function(test_input)
+    mocker.patch("fixate.core.common.warnings")
+    assert test_input == mock_function(test_input)
 
 
 class Foo:

--- a/test/core/test_jig_mapping.py
+++ b/test/core/test_jig_mapping.py
@@ -582,4 +582,4 @@ class TestRelayMuxClearingTime(TestCase):
         self.jig.mux.Mux1("")
         self.jig.mux.Mux2("")
         self.jig.mux.Mux3("")
-        self.assertEquals(None, self.handler_mock.update_output.assert_not_called())
+        self.assertEqual(None, self.handler_mock.update_output.assert_not_called())

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
-# py34 should work. But pypubsub appears to not install 3rd party typing
-# correctly, so punting that for now.
-envlist = py35, py36, py37
+envlist = py36,py37
 
 [testenv]
 deps = -rrequirements-test
@@ -16,3 +14,7 @@ deps =
     setuptools
 commands =
     python setup.py -q sdist bdist_wheel
+
+[pytest]
+# https://docs.pytest.org/en/stable/deprecations.html#junit-family-default-value-change-to-xunit2
+junit_family=xunit2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37
+envlist = py36,py37,py38
 
 [testenv]
 deps = -rrequirements-test
@@ -18,3 +18,5 @@ commands =
 [pytest]
 # https://docs.pytest.org/en/stable/deprecations.html#junit-family-default-value-change-to-xunit2
 junit_family=xunit2
+python_classes =
+testpaths = test


### PR DESCRIPTION
- Drop 3.5, since we don't really have a need to keep that
  build running
- Fix a deprecation with the xml reporting format
- Fix a deprecation of the assertEquals method
- mocker can't be used as a context manger when it is
  being run as a pytest fixture.