### PR TITLE
Added scoped test data implementation.

### DIFF
--- a/src/fixate/core/common.py
+++ b/src/fixate/core/common.py
@@ -448,7 +448,7 @@ class TestClass:
         Optionally override this code that is always executed at the end of the test whether it was successful or not
         """
 
-    def test(self):
+    def test(self, **kwargs):
         """
         This method should be overridden with the test code
         This is the test sequence code

--- a/src/fixate/examples/shared_test_data.py
+++ b/src/fixate/examples/shared_test_data.py
@@ -1,0 +1,76 @@
+from fixate.core.ui import user_info
+from fixate.core.common import TestClass, TestList
+import fixate
+
+__version__ = "2"
+
+seq = fixate.config.RESOURCES["SEQUENCER"]
+
+
+class TestListOuter(TestList):
+    outer: int
+    other_data: float
+
+    def __init__(self, seq, *, outer: int = 5):
+        super(TestListOuter, self).__init__(seq)
+        self.outer = outer
+
+    def enter(self):
+        self.other_data = 0.5
+
+
+class TestListInner(TestList):
+    inner: int
+    other_data: str
+
+    def enter(self):
+        self.inner = 10
+        self.other_data = "Hello"
+
+
+class TestListNotRun(TestList):
+    other_data: int
+
+
+class TestOuter(TestClass):
+    def test(self, outer_list: TestListOuter):
+        user_info(f"Outer.outer: {outer_list.outer}")
+        user_info(f"Outer.other: {outer_list.other_data}")
+
+
+class TestBoth(TestClass):
+    def test(self, outer_list: TestListOuter, inner_list: TestListInner):
+        user_info(f"Outer.outer: {outer_list.outer}")
+        user_info(f"Outer.other: {outer_list.other_data}")
+        user_info(f"Inner.inner: {inner_list.inner}")
+        user_info(f"Inner.other: {inner_list.other_data}")
+
+
+class TestOther(TestClass):
+    def test(self, outer_list: TestListOuter, inner_list: TestListInner, not_run: TestListNotRun):
+        user_info(f"Outer.outer: {outer_list.outer}")
+        user_info(f"Outer.other: {outer_list.other_data}")
+        user_info(f"Inner.inner: {inner_list.inner}")
+        user_info(f"Inner.other: {inner_list.other_data}")
+
+
+test_data = {
+    "standard": TestList([TestListOuter([TestListInner([TestBoth()])])]),
+    # Should fail as TestListNotRun in not run
+    "test_not_run": TestList([TestListOuter([TestListInner([TestOther()])])]),
+    # Should fail as TestBoth doesn't have TestListOuter in scope
+    "list_out_of_scope": TestList([TestListOuter([TestOuter()]), TestListInner([TestBoth()])]),
+    # Should use the inner most match to the test list. First TestOuter should print 10, second should print 20
+    # Eg. 1.1 Outer.outer: 10, 1.2.1 Outer.outer: 20
+    "used_multi_level": TestList([
+        TestListOuter(
+            [
+                TestOuter(),
+                TestListOuter([
+                    TestOuter()
+                ], outer=20),
+
+            ],
+            outer=10)
+    ])
+}


### PR DESCRIPTION
### Features:

- Readable, less mental overhead to workout what is going on
- Explicit TestListType declaration. You know exactly which test list class you are working with
- Full auto_complete, type hinting allows for autocomplete on the object
- No metaclass magic​. The implementation is quite simple (unlike my other metaclass magic implementations)
- No Decorators
- Backward compatible, can easily add back to existing tests to replace the context_data on a staged approach
- Forced test scoping, test data cannot be shared across test lists, only those up the stack
- If there are duplicate class matches, it will use the test list closest to it in the stack.

### Implementation Details:

- I have hooked into the inspect module and type annotations.
- In the sequencer
- At the beginning of the test (before all the setup methods are called) I create a fresh dictionary.
- I populate the dictionary with the test lists it encounters along the way. 
- Instead of just calling active_test.test(), I first inspect active_test.test's type annotations.
- I then key, value match the type annotated parameters with values stored in the dictionary
- If any values are missing it will throw a test error
- If there are duplicate matches of a class (eg using The same list type at two different levels), it will match to the test list closest to it in the stack.