### PR TITLE
Fix process for invalid serial number entries

### DIFF
--- a/src/fixate/__main__.py
+++ b/src/fixate/__main__.py
@@ -252,6 +252,7 @@ class FixateWorker:
     def ui_run(self):
 
         serial_number = None
+        serial_response = None
         test_selector = None
         self.start = True
 

--- a/src/fixate/__main__.py
+++ b/src/fixate/__main__.py
@@ -2,6 +2,7 @@ import logging
 import logging.handlers
 import os
 import sys
+from enum import Enum
 from argparse import ArgumentParser, RawTextHelpFormatter
 from functools import partial
 from importlib.machinery import SourceFileLoader
@@ -9,7 +10,7 @@ from zipimport import zipimporter
 from pubsub import pub
 import fixate.config
 from fixate.core.exceptions import SequenceAbort
-from fixate.core.ui import user_serial, user_ok
+from fixate.core.ui import user_info_important, user_serial, user_ok
 from fixate.reporting import register_csv, unregister_csv
 from fixate.ui_cmdline import register_cmd_line, unregister_cmd_line
 import fixate.sequencer
@@ -23,6 +24,16 @@ Fixate Command Line Interface
 )
 
 logger = logging.getLogger(__name__)
+
+
+class ReturnCodes(int, Enum):
+    """Fixate Return codes"""
+
+    PASS = 5
+    FAIL = 10
+    ABORTED = 11
+    ERROR = 12
+
 
 # Optional Arguments
 mutex_group = parser.add_mutually_exclusive_group()
@@ -236,7 +247,7 @@ class FixateWorker:
             "Sequence_Abort", exception=SequenceAbort("Application Closing")
         )
 
-        return 11
+        return ReturnCodes.ABORTED
 
     def ui_run(self):
 
@@ -250,12 +261,19 @@ class FixateWorker:
                 fixate.config.DEBUG = True
 
             if self.args.serial_number is None:
-                serial_number = user_serial("Please enter serial number")
-                self.sequencer.context_data["serial_number"] = serial_number[1]
-                if serial_number == "ABORT_FORCE":
-                    return
+                serial_response = user_serial("Please enter serial number")
+                if serial_response == "ABORT_FORCE":
+                    return ReturnCodes.ABORTED
+                elif serial_response[0] == "Exception":
+                    # Should be tuple: ("Exception", <Exception>)
+                    raise serial_response[1]
+                else:
+                    # Should be tuple: ("Result", serial_number)
+                    serial_number = serial_response[1]
+                    self.sequencer.context_data["serial_number"] = serial_number
             else:
-                self.sequencer.context_data["serial_number"] = self.args.serial_number
+                serial_number = self.args.serial_number
+                self.sequencer.context_data["serial_number"] = serial_number
 
             if self.test_script_path is None:
                 self.test_script_path = self.args.path
@@ -293,22 +311,26 @@ class FixateWorker:
         except BaseException:
             import traceback
 
+            user_info_important("Exception - see terminal for details")
             input(traceback.print_exc())
             raise
         finally:
             unregister_csv()
-            if serial_number == "ABORT_FORCE" or test_selector == "ABORT_FORCE":
-                return 11
+            if serial_response == "ABORT_FORCE" or test_selector == "ABORT_FORCE":
+                return ReturnCodes.ABORTED
+            if serial_number is None:
+                # Error at serial number input stage
+                return ReturnCodes.ERROR
             # Let the supervisor know that the program is finishing normally
             self.clean = True
             if self.sequencer.end_status == "FAILED":
-                return 10
+                return ReturnCodes.FAIL
             elif self.sequencer.status == "Aborted":
-                return 11
+                return ReturnCodes.ABORTED
             elif self.sequencer.end_status == "ERROR":
-                return 12
+                return ReturnCodes.ERROR
             else:
-                return 5
+                return ReturnCodes.PASS
 
 
 def retrieve_test_data(test_suite, index):

--- a/src/fixate/core/ui.py
+++ b/src/fixate/core/ui.py
@@ -89,6 +89,7 @@ def user_input(msg):
 
 
 def _float_validate(entry):
+    """Requires float entry"""
     try:
         return float(entry)
     except ValueError:
@@ -204,6 +205,7 @@ def _user_choices(response, choices):
 
 
 def _ten_digit_serial(response):
+    """Requires 10-digit integer"""
     return (len(response) == 10) and int(response)
 
 

--- a/src/fixate/reporting/__init__.py
+++ b/src/fixate/reporting/__init__.py
@@ -1,1 +1,1 @@
-from fixate.reporting.csv import register_csv, unregister_csv, writer
+from fixate.reporting.csv import register_csv, unregister_csv

--- a/src/fixate/reporting/__init__.py
+++ b/src/fixate/reporting/__init__.py
@@ -1,1 +1,1 @@
-from fixate.reporting.csv import register_csv, unregister_csv
+from fixate.reporting.csv import register_csv, unregister_csv, writer

--- a/src/fixate/reporting/csv.py
+++ b/src/fixate/reporting/csv.py
@@ -386,12 +386,13 @@ def unregister_csv():
     :return:
     """
     global writer
-    pub.unsubscribe(writer.reporting.test_start, "Test_Start")
-    pub.unsubscribe(writer.reporting.test_comparison, "Check")
-    pub.unsubscribe(writer.reporting.test_exception, "Test_Exception")
-    pub.unsubscribe(writer.reporting.test_complete, "Test_Complete")
-    pub.unsubscribe(writer.reporting.sequence_update, "Sequence_Update")
-    pub.unsubscribe(writer.reporting.sequence_complete, "Sequence_Complete")
-    pub.unsubscribe(writer.reporting.user_wait_start, "UI_block_start")
-    pub.unsubscribe(writer.reporting.user_wait_end, "UI_block_end")
-    writer.uninstall()
+    if writer is not None:
+        pub.unsubscribe(writer.reporting.test_start, "Test_Start")
+        pub.unsubscribe(writer.reporting.test_comparison, "Check")
+        pub.unsubscribe(writer.reporting.test_exception, "Test_Exception")
+        pub.unsubscribe(writer.reporting.test_complete, "Test_Complete")
+        pub.unsubscribe(writer.reporting.sequence_update, "Sequence_Update")
+        pub.unsubscribe(writer.reporting.sequence_complete, "Sequence_Complete")
+        pub.unsubscribe(writer.reporting.user_wait_start, "UI_block_start")
+        pub.unsubscribe(writer.reporting.user_wait_end, "UI_block_end")
+        writer.uninstall()

--- a/src/fixate/ui_cmdline/cmd_line.py
+++ b/src/fixate/ui_cmdline/cmd_line.py
@@ -230,8 +230,12 @@ def _user_input(msg, q, target=None, attempts=5, kwargs=None):
             q.put(("Result", ret_val))
             return
     q.put(
-        "Exception",
-        UserInputError("Maximum number of attempts {} reached".format(attempts)),
+        (
+            "Exception",
+            UserInputError(f"Maximum number of attempts {attempts} reached."),
+            # Might be helpful to print a message about the target ^
+            # i.e. target.__name__?
+        )
     )
 
 
@@ -362,7 +366,7 @@ def _print_comparisons(passes, chk, chk_cnt, context):
                     comparison=chk.target.__name__[1:].replace("_", " "),
                     chk_cnt=chk_cnt,
                     description=chk.description,
-                    **format_dict
+                    **format_dict,
                 )
             )
         )
@@ -375,7 +379,7 @@ def _print_comparisons(passes, chk, chk_cnt, context):
                     comparison=chk.target.__name__[1:].replace("_", " "),
                     chk_cnt=chk_cnt,
                     description=chk.description,
-                    **format_dict
+                    **format_dict,
                 )
             )
         )
@@ -395,7 +399,7 @@ def _print_comparisons(passes, chk, chk_cnt, context):
                     comp_val=comp_val,
                     chk_cnt=chk_cnt,
                     description=chk.description,
-                    **format_dict
+                    **format_dict,
                 )
             )
         )
@@ -407,7 +411,7 @@ def _print_comparisons(passes, chk, chk_cnt, context):
                         chk_cnt=chk_cnt,
                         description=chk.description,
                         status=status,
-                        **format_dict
+                        **format_dict,
                     )
                 )
             )

--- a/src/fixate/ui_cmdline/cmd_line.py
+++ b/src/fixate/ui_cmdline/cmd_line.py
@@ -229,14 +229,10 @@ def _user_input(msg, q, target=None, attempts=5, kwargs=None):
         if ret_val:
             q.put(("Result", ret_val))
             return
-    q.put(
-        (
-            "Exception",
-            UserInputError(f"Maximum number of attempts {attempts} reached."),
-            # Might be helpful to print a message about the target ^
-            # i.e. target.__name__?
-        )
-    )
+    # Display failure of target and send exception
+    error_str = f"Maximum number of attempts {attempts} reached. {target.__doc__}"
+    _user_display(error_str)
+    q.put(("Exception", UserInputError(error_str)))
 
 
 def _user_display(msg):

--- a/src/fixate/ui_gui_qt/ui_gui_qt.py
+++ b/src/fixate/ui_gui_qt/ui_gui_qt.py
@@ -739,14 +739,10 @@ class FixateGUI(QtWidgets.QMainWindow, layout.Ui_FixateUI):
             if ret_val:
                 q.put(("Result", ret_val))
                 return
-        q.put(
-            (
-                "Exception",
-                UserInputError(f"Maximum number of attempts {attempts} reached"),
-                # Might be helpful to print a message about the target ^
-                # i.e. target.__name__?
-            )
-        )
+        # Display failure of target and send exception
+        error_str = f"Maximum number of attempts {attempts} reached. {target.__doc__}"
+        self._topic_UI_display(error_str)
+        q.put(("Exception", UserInputError(error_str)))
 
     def _topic_UI_display(self, msg):
         """

--- a/src/fixate/ui_gui_qt/ui_gui_qt.py
+++ b/src/fixate/ui_gui_qt/ui_gui_qt.py
@@ -740,8 +740,12 @@ class FixateGUI(QtWidgets.QMainWindow, layout.Ui_FixateUI):
                 q.put(("Result", ret_val))
                 return
         q.put(
-            "Exception",
-            UserInputError("Maximum number of attempts {} reached".format(attempts)),
+            (
+                "Exception",
+                UserInputError(f"Maximum number of attempts {attempts} reached"),
+                # Might be helpful to print a message about the target ^
+                # i.e. target.__name__?
+            )
         )
 
     def _topic_UI_display(self, msg):
@@ -924,7 +928,7 @@ class FixateGUI(QtWidgets.QMainWindow, layout.Ui_FixateUI):
                     comparison=chk.target.__name__[1:].replace("_", " "),
                     chk_cnt=chk_cnt,
                     description=chk.description,
-                    **format_dict
+                    **format_dict,
                 )
             )
             self.sig_history_update.emit(msg)
@@ -938,7 +942,7 @@ class FixateGUI(QtWidgets.QMainWindow, layout.Ui_FixateUI):
                     comparison=chk.target.__name__[1:].replace("_", " "),
                     chk_cnt=chk_cnt,
                     description=chk.description,
-                    **format_dict
+                    **format_dict,
                 )
             )
             self.sig_history_update.emit(msg)
@@ -959,7 +963,7 @@ class FixateGUI(QtWidgets.QMainWindow, layout.Ui_FixateUI):
                     comp_val=comp_val,
                     chk_cnt=chk_cnt,
                     description=chk.description,
-                    **format_dict
+                    **format_dict,
                 )
             )
             self.sig_history_update.emit(msg)
@@ -972,7 +976,7 @@ class FixateGUI(QtWidgets.QMainWindow, layout.Ui_FixateUI):
                         chk_cnt=chk_cnt,
                         description=chk.description,
                         status=status,
-                        **format_dict
+                        **format_dict,
                     )
                 )
                 self.sig_history_update.emit(msg)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,black
+envlist = py37,py38,py39,py310,black
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Fixed the handling of invalid serial numbers:
- Properly return tuple from user_inputs. Previously it was not returning a tuple for the exception and instead parsed the serial number as "x" i.e. "E**x**ception"[1].
- Properly raises exception now which prevents starting the sequence and returns an error code
- Add info to the UI to display that an exception has occurred (previously if using GUI - would stay at "loading" and issue could only be noticed in the background terminal).

Other:
- Created enum to make return codes clearer
- Prevent unhandled exception caused by trying to close the csv_writer if fixate failed before opening it.

