### PR TITLE
Update driver imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ venv/
 venv
 venv37
 .venv
+.vscode/settings.json

--- a/src/fixate/config/__init__.py
+++ b/src/fixate/config/__init__.py
@@ -23,7 +23,6 @@ import re
 
 LOCAL_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "local_config.json")
 
-INSTRUMENTS = []
 RESOURCES = {}
 
 DEBUG = False
@@ -62,6 +61,9 @@ class InstrumentConfig:
     address: str
     instrument_type: InstrumentType
     parameters: Dict[str, str]
+
+
+INSTRUMENTS: List[InstrumentConfig] = []
 
 
 def load_local_config(local_config_path: str) -> List[InstrumentConfig]:
@@ -149,6 +151,8 @@ def load_config(config_files: Optional[List[str]] = None):
     INSTRUMENTS[:] = list(load_local_config(LOCAL_CONFIG_PATH))
 
 
+# Issues with this - it only loads the first match in the config
+# therefore unable to have multiple dmm's stored on same computer
 def find_instrument_by_id(regex_id) -> Optional[InstrumentConfig]:
     """Search for instruments whose id matches the regex passed in.
 
@@ -156,5 +160,7 @@ def find_instrument_by_id(regex_id) -> Optional[InstrumentConfig]:
     """
     for instrument_config in INSTRUMENTS:
         if re.search(regex_id, instrument_config.id):
+            # Alternatively could test opening here?
+            # But if test opening, might as well open???
             return instrument_config
     return None

--- a/src/fixate/drivers/dmm/__init__.py
+++ b/src/fixate/drivers/dmm/__init__.py
@@ -10,14 +10,18 @@ dmm.reset()
 import fixate.drivers
 from fixate.drivers.dmm.helper import DMM
 from fixate.drivers.dmm.fluke_8846a import Fluke8846A
-from fixate.drivers import find_instrument_by_id
+from fixate.drivers import find_instruments_by_id, filter_connected_visa
 
 
 def open() -> DMM:
-    instrument = find_instrument_by_id(Fluke8846A.REGEX_ID)
+    # Find all flukes in local config
+    dmm_configs = find_instruments_by_id(Fluke8846A.REGEX_ID)
+    # Find and open first connected instrument
+    instrument = filter_connected_visa(dmm_configs)
     if instrument is not None:
-        # we've found and connected to a visa instrument
+        # Instantiate driver from visa connection
         driver = Fluke8846A(instrument)
         fixate.drivers.log_instrument_open(driver)
         return driver
+
     raise fixate.drivers.InstrumentNotFoundError

--- a/src/fixate/drivers/dmm/__init__.py
+++ b/src/fixate/drivers/dmm/__init__.py
@@ -7,20 +7,17 @@ Functions are dictacted by the metaclass in helper.py
 dmm.measure(*mode, **mode_params)
 dmm.reset()
 """
-import pyvisa
 import fixate.drivers
 from fixate.drivers.dmm.helper import DMM
 from fixate.drivers.dmm.fluke_8846a import Fluke8846A
-from fixate.config import find_instrument_by_id
+from fixate.drivers import find_instrument_by_id
 
 
 def open() -> DMM:
     instrument = find_instrument_by_id(Fluke8846A.REGEX_ID)
     if instrument is not None:
-        # we've found a connected instrument so open and return it
-        rm = pyvisa.ResourceManager()
-        # open_resource could raise visa.VisaIOError?
-        driver = Fluke8846A(rm.open_resource(instrument.address))
+        # we've found and connected to a visa instrument
+        driver = Fluke8846A(instrument)
         fixate.drivers.log_instrument_open(driver)
         return driver
     raise fixate.drivers.InstrumentNotFoundError


### PR DESCRIPTION
Update the driver imports to try opening all matching visa instruments until one is successfully connected.

Fixes current issue where it only attempts to open the first instrument of the desired type in the local_config.

**NOTE**: only applied to the dmm for now. Would end up removing find_instrument_by_id from the config/__init__.