### PR TITLE
Fix local pytest log checking

### DIFF
--- a/test/core/expect-logs/fixate.yml
+++ b/test/core/expect-logs/fixate.yml
@@ -1,0 +1,14 @@
+tpl_csv_path: "{start_date_time}-{index}.csv"
+tpl_time_stamp: '{0:%Y}{0:%m}{0:%d}-{0:%H}{0:%M}{0:%S}'
+
+plg_csv:
+  import_name: fixate.reporting.csv
+  REPORT_FORMAT_VERSION: 3
+  tpl_first_line:
+  - "0"
+  - Sequence
+  - started={start_date_time}
+  - fixate-version={fixate_version}
+  - test-script-name={test_script_name}
+  - report-format={REPORT_FORMAT_VERSION}
+  - index_string={index}

--- a/test/core/test_script2log.py
+++ b/test/core/test_script2log.py
@@ -60,6 +60,7 @@ def test_basicpass(tmpdir):
             "--log-file",
             log_path,
             "--non-interactive",
+            "--disable-logs",
         ]
     )
     assert ret == 5
@@ -83,6 +84,7 @@ def test_basicfail(tmpdir):
             "--log-file",
             log_path,
             "--non-interactive",
+            "--disable-logs",
         ]
     )
     assert ret == 10
@@ -158,6 +160,7 @@ def test_basichierachy(tmpdir, fail_flag, raise_flag, xfail, return_code):
             "fail_flag=" + fail_flag,
             "--script-params",
             "raise_flag=" + raise_flag,
+            "--disable-logs",
         ]
     )
 

--- a/test/core/test_script2log.py
+++ b/test/core/test_script2log.py
@@ -34,12 +34,13 @@ def compare_logs(test_log, expected_log):
         dict_line(expected_first),
         filter_keys={"started", "fixate-version"},
     )
-    # CHeck last line
+    # Check last line
     compare_dicts(dict_line(test_last), dict_line(expected_last), filter_keys={"ended"})
 
 
 log_dir = os.path.join(os.path.dirname(__file__), "expect-logs")
 script_dir = os.path.join(os.path.dirname(__file__), "scripts")
+local_config = os.path.join(log_dir, "fixate.yml")
 
 
 def test_basicpass(tmpdir):
@@ -52,6 +53,8 @@ def test_basicpass(tmpdir):
             "fixate",
             "-p",
             script_path,
+            "-c",
+            local_config,
             "--serial-number",
             "0123456789",
             "--log-file",
@@ -73,6 +76,8 @@ def test_basicfail(tmpdir):
             "fixate",
             "-p",
             script_path,
+            "-c",
+            local_config,
             "--serial-number",
             "0123456789",
             "--log-file",
@@ -142,6 +147,8 @@ def test_basichierachy(tmpdir, fail_flag, raise_flag, xfail, return_code):
             "fixate",
             "-p",
             script_path,
+            "-c",
+            local_config,
             "--serial-number",
             "0123456789",
             "--log-file",


### PR DESCRIPTION
Overwrite any potential local_config (fixate.yml) so pytests can be run locally.

Since the change in config file directories - local fixate.yml lives and persists outside the venv. This causes it to override the default logging format which the test_script2log expects. Therefore when tests are run locally they will fail when fixate.yml differs from the default.

Two possible options:
1. Re-overwrite the fixate.yml with the default (quick/dirty solution - I have done here initially)
2. Remove the fixate.yml as a 'global' config that is always used and instead pass it independently through the --config command line arg.

Since it is a subprocess call I don't believe we can patch something into fixate.