### PR TITLE
Change default returncode to Error

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -9,6 +9,7 @@ Release Date xx/xx/xxxx
 - Fix initial serial number check to properly raise exception on incorrect entry.
 - Failure to open a drivers pyvisa resource will now raise a more informative InstrumentOpenError exception from the pyvisa error
 - Add optional formatting argument ('fmt') to check functions to improve ui display and logging of test values
+- Fix bug where sequencer would return success if terminated during startup
 
 *************
 Version 0.6.0

--- a/src/fixate/__main__.py
+++ b/src/fixate/__main__.py
@@ -328,10 +328,11 @@ class FixateWorker:
                 return ReturnCodes.FAIL
             elif self.sequencer.status == "Aborted":
                 return ReturnCodes.ABORTED
-            elif self.sequencer.end_status == "ERROR":
-                return ReturnCodes.ERROR
-            else:
+            elif self.sequencer.end_status == "PASSED":
                 return ReturnCodes.PASS
+            else:
+                # Default to Error
+                return ReturnCodes.ERROR
 
 
 def retrieve_test_data(test_suite, index):

--- a/src/fixate/sequencer.py
+++ b/src/fixate/sequencer.py
@@ -386,7 +386,6 @@ class Sequencer:
     def _handle_sequence_abort(self):
         self.status = "Aborted"
         self.ABORT = True
-        self.test_running = False
 
     def check(self, chk: CheckResult):
         """Update current pass/fail counts and send check criteria to subscribers"""


### PR DESCRIPTION
Change default returncode to Error - only way it should pass is by finishing under correct conditions. 
(more details in CPE-2586)

Delete unused sequencer variable.