### PR TITLE
Increment version + add 3.11 tox env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/src/fixate/__init__.py
+++ b/src/fixate/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.1.post1"
+__version__ = "0.6.2-dev"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,black
+envlist = py37,py38,py39,py310,py311,black
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Prep version for dev work.
Add 3.11 to tox env - to match git workflow.
Remove -dev from py3.11 git workflow version.