### PR TITLE
Add computername logging

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -2,6 +2,19 @@
 Release Notes
 ==================================
 *************
+Version 0.6.2
+*************
+Release Date XX/XX/XX
+
+New Features
+############
+- 
+
+Improvements
+############
+- Add logging of computer name to log file.
+
+*************
 Version 0.6.1
 *************
 Release Date 22/05/2023

--- a/src/fixate/config/__init__.py
+++ b/src/fixate/config/__init__.py
@@ -12,6 +12,8 @@ from fixate.config.helper import (
     get_config_dict,
     render_template,
 )
+
+import platform
 import os.path
 import json
 import dataclasses
@@ -28,13 +30,7 @@ CONFIG_DIRECTORY = Path(platformdirs.site_config_dir("Fixate", False))
 LOG_DIRECTORY = Path(platformdirs.user_log_dir("Fixate", False))
 INSTRUMENT_CONFIG_FILE = CONFIG_DIRECTORY / "instruments.json"
 
-try:
-    COMPUTERNAME = os.environ["COMPUTERNAME"]  # On Windows
-except KeyError:
-    COMPUTERNAME = os.uname().nodename  # On POSIX
-except AttributeError:
-    # Cant get the computer name
-    COMPUTERNAME = "Unknown"
+COMPUTERNAME = platform.node()  # Computer name, or empty string if unavailable.
 
 INSTRUMENTS = []
 RESOURCES = {}

--- a/src/fixate/config/__init__.py
+++ b/src/fixate/config/__init__.py
@@ -28,6 +28,13 @@ CONFIG_DIRECTORY = Path(platformdirs.site_config_dir("Fixate", False))
 LOG_DIRECTORY = Path(platformdirs.user_log_dir("Fixate", False))
 INSTRUMENT_CONFIG_FILE = CONFIG_DIRECTORY / "instruments.json"
 
+try:
+    COMPUTERNAME = os.environ["COMPUTERNAME"]  # On Windows
+except KeyError:
+    COMPUTERNAME = os.uname().nodename  # On POSIX
+except AttributeError:
+    # Cant get the computer name
+    COMPUTERNAME = "Unknown"
 
 INSTRUMENTS = []
 RESOURCES = {}
@@ -51,6 +58,7 @@ plg_csv = {
         "test-script-name={test_script_name}",
         "report-format={REPORT_FORMAT_VERSION}",
         "index_string={index}",
+        "computername={COMPUTERNAME}",
     ],
 }
 

--- a/test/core/expect-logs/fixate_with_computername.yml
+++ b/test/core/expect-logs/fixate_with_computername.yml
@@ -1,0 +1,15 @@
+tpl_csv_path: "{start_date_time}-{index}.csv"
+tpl_time_stamp: '{0:%Y}{0:%m}{0:%d}-{0:%H}{0:%M}{0:%S}'
+
+plg_csv:
+  import_name: fixate.reporting.csv
+  REPORT_FORMAT_VERSION: 3
+  tpl_first_line:
+  - "0"
+  - Sequence
+  - started={start_date_time}
+  - fixate-version={fixate_version}
+  - test-script-name={test_script_name}
+  - report-format={REPORT_FORMAT_VERSION}
+  - index_string={index}
+  - COMPUTERNAME={COMPUTERNAME}

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ isolated_build = True
 [testenv]
 extras = test
 commands = pytest --junitxml=junit/test-results.xml --cov=fixate --cov-report=xml --cov-report=html -m "not drivertest"
+passenv = COMPUTERNAME
 
 # I've removed the pin on PyDAQmx but going to leave this here for the moment
 # in case I need to put it back.

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ isolated_build = True
 [testenv]
 extras = test
 commands = pytest --junitxml=junit/test-results.xml --cov=fixate --cov-report=xml --cov-report=html -m "not drivertest"
-passenv = COMPUTERNAME
 
 # I've removed the pin on PyDAQmx but going to leave this here for the moment
 # in case I need to put it back.


### PR DESCRIPTION
Recently I have been wanting to filter fixate logs by asset number to get an idea if a specific amptower has been failing more than others. This should allow us to do this. 

I am not sure how to write a test for this, as the computername string will change every time fixate is run on a new computer. Maybe someone has as idea? 