### PR TITLE
Dmm driver improvements

### DIFF
--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -2,6 +2,18 @@
 Release Notes
 ==================================
 *************
+Version 0.6.2
+*************
+Release Date xx/xx/xxxx
+
+New Features
+############
+
+Improvements
+############
+- Update DMM driver with optional measurement delay to improve DMM model compatibility.
+
+*************
 Version 0.6.1
 *************
 Release Date 22/05/2023

--- a/src/fixate/drivers/dmm/__init__.py
+++ b/src/fixate/drivers/dmm/__init__.py
@@ -26,7 +26,9 @@ def open() -> DMM:
             try:
                 resource = rm.open_resource(instrument.address)
             except pyvisa.VisaIOError as e:
-                raise InstrumentOpenError(f"Unable to open DMM: {instrument.address}") from e
+                raise InstrumentOpenError(
+                    f"Unable to open DMM: {instrument.address}"
+                ) from e
             # Instantiate driver with connected instrument
             driver = DMM(resource)
             fixate.drivers.log_instrument_open(driver)

--- a/src/fixate/drivers/dmm/__init__.py
+++ b/src/fixate/drivers/dmm/__init__.py
@@ -18,9 +18,7 @@ from fixate.drivers.dmm.helper import DMM
 
 
 def open() -> DMM:
-
     for DMM in (Fluke8846A, Keithley6500):
-
         instrument = find_instrument_by_id(DMM.REGEX_ID)
         if instrument is not None:
             # We've found a configured instrument so try to open it
@@ -28,9 +26,7 @@ def open() -> DMM:
             try:
                 resource = rm.open_resource(instrument.address)
             except pyvisa.VisaIOError as e:
-                raise InstrumentOpenError(
-                    f"Unable to open DMM: {instrument.address}"
-                ) from e
+                raise InstrumentOpenError(f"Unable to open DMM: {instrument.address}") from e
             # Instantiate driver with connected instrument
             driver = DMM(resource)
             fixate.drivers.log_instrument_open(driver)

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -9,9 +9,8 @@ class Fluke8846A(DMM):
     INSTR_TYPE = "VISA"
 
     def __init__(self, instrument, *args, **kwargs):
-        self.measurement_delay = (
-            0.2  # Delay between call to self.measurement() and querying the DMM.
-        )
+        # Delay between call to self.measurement() and querying the DMM.
+        self.measurement_delay = 0
         self.instrument = instrument
         instrument.rtscts = 1
         self.lock = Lock()
@@ -81,15 +80,18 @@ class Fluke8846A(DMM):
         self._write("*TRG")  # Send trigger to instrument
         self._is_error()  # Catch errors. This might slow things down
 
-    def measurement(self, delay=False):
+    def measurement(self, delay=None):
         """
         Sets up DMM triggering, creates list of measurements from the read buffer
 
-        delay: If True, will wait for self.measurement_delay seconds before triggering a measurement.
+        delay: If not set, will wait for self.measurement_delay seconds before triggering a measurement. If set, will wait for delay seconds before triggering a measurement.
         returns: a single value as a float
         """
-        if delay:
-            time.sleep(self.measurement_delay)
+        if delay is None:
+            delay = self.measurement_delay
+
+        if delay > 0:
+            time.sleep(delay)
         return self.measurements()[0]
 
     def measurements(self):

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -188,7 +188,9 @@ class Fluke8846A(DMM):
             else:
                 raise InstrumentError(
                     "Error(s) Returned from DMM\n"
-                    + "\n".join([f"Code: {code}\nMessage:{msg}" for code, msg in errors])
+                    + "\n".join(
+                        [f"Code: {code}\nMessage:{msg}" for code, msg in errors]
+                    )
                 )
 
     def _set_measurement_mode(self, mode, _range=None, suffix=None):

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -1,7 +1,5 @@
 from threading import Lock
-from pyvisa import constants
 from fixate.core.exceptions import InstrumentError, ParameterError
-from fixate.core.common import mode_builder, deprecated
 from fixate.drivers.dmm.helper import DMM
 import time
 
@@ -43,27 +41,7 @@ class Fluke8846A(DMM):
             "continuity": "CONF:CONTinuity",
             "diode": "CONF:DIODe",
         }
-        self._filters = {
-            "voltage_ac": "SENS:VOLT:AC",
-            "voltage_dc": "SENS:VOLT:DC",
-            "current_ac": "SENS:CURR:AC",
-            "current_dc": "SENS:CURR:DC",
-            "resistance": "SENS:RES",
-            "fresistance": "SENS:FRES",
-            None: "",
-        }
         self._init_string = ""  # Unchanging
-
-        self._resolution = {
-            "voltage_ac": "VOLT:RES",
-            "voltage_dc": "VOLT:RES",
-            "current_ac": "CURR:AC:RES",
-            "current_dc": "CURR:DC:RES",
-            "resistance": "RES:RES",
-            "fresistance": "RES:RES",
-            "capacitance": "CAP:RES",
-            None: "",
-        }
 
     @property
     def samples(self):
@@ -219,7 +197,6 @@ class Fluke8846A(DMM):
         resistance, fresistance. Reduces previous duplicate code.
         :param mode:
         :param _range:
-        :param _resolution:
         :return:
         """
         self.mode = mode
@@ -287,7 +264,6 @@ class Fluke8846A(DMM):
         """
         Writes configuration string for diode to the DMM
         param _range: value set for the range
-        param _resolution: value set for the resolution
         """
         self._set_measurement_mode(
             "diode",
@@ -298,7 +274,6 @@ class Fluke8846A(DMM):
         """
         Writes configuration string for continuity to the DMM
         param _range: value set for the range
-        param _resolution: value set for the resolution
         """
         self._set_measurement_mode("continuity")
 

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -9,7 +9,9 @@ class Fluke8846A(DMM):
     INSTR_TYPE = "VISA"
 
     def __init__(self, instrument, *args, **kwargs):
-        self.measurement_delay = 0.2 # Delay between call to self.measurement() and querying the DMM.
+        self.measurement_delay = (
+            0.2  # Delay between call to self.measurement() and querying the DMM.
+        )
         self.instrument = instrument
         instrument.rtscts = 1
         self.lock = Lock()
@@ -82,7 +84,7 @@ class Fluke8846A(DMM):
     def measurement(self, delay=False):
         """
         Sets up DMM triggering, creates list of measurements from the read buffer
-        
+
         delay: If True, will wait for self.measurement_delay seconds before triggering a measurement.
         returns: a single value as a float
         """
@@ -186,9 +188,7 @@ class Fluke8846A(DMM):
             else:
                 raise InstrumentError(
                     "Error(s) Returned from DMM\n"
-                    + "\n".join(
-                        [f"Code: {code}\nMessage:{msg}" for code, msg in errors]
-                    )
+                    + "\n".join([f"Code: {code}\nMessage:{msg}" for code, msg in errors])
                 )
 
     def _set_measurement_mode(self, mode, _range=None, suffix=None):

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -11,6 +11,7 @@ class Fluke8846A(DMM):
     INSTR_TYPE = "VISA"
 
     def __init__(self, instrument, *args, **kwargs):
+        self.measurement_delay = 0.2 # Delay between call to self.measurement() and querying the DMM.
         self.instrument = instrument
         instrument.rtscts = 1
         self.lock = Lock()
@@ -100,11 +101,15 @@ class Fluke8846A(DMM):
         self._write("*TRG")  # Send trigger to instrument
         self._is_error()  # Catch errors. This might slow things down
 
-    def measurement(self):
+    def measurement(self, delay=False):
         """
         Sets up DMM triggering, creates list of measurements from the read buffer
+        
+        delay: If True, will wait for self.measurement_delay seconds before triggering a measurement.
         returns: a single value as a float
         """
+        if delay:
+            time.sleep(self.measurement_delay)
         return self.measurements()[0]
 
     def measurements(self):

--- a/src/fixate/drivers/dmm/helper.py
+++ b/src/fixate/drivers/dmm/helper.py
@@ -28,7 +28,13 @@ class DMM:
         """
         raise NotImplementedError
 
-    def measurement(self):
+    def measurement(self, delay=False):
+        """
+        Trigger and return measurement from the instrument buffer.
+
+        delay: If True, waits for self.measurement_delay seconds then triggers a measurement.
+        returns: a single value as a float
+        """
         raise NotImplementedError
 
     def voltage_ac(self, _range=None):

--- a/src/fixate/drivers/dmm/helper.py
+++ b/src/fixate/drivers/dmm/helper.py
@@ -28,7 +28,7 @@ class DMM:
         """
         raise NotImplementedError
 
-    def measurement(self, delay=False):
+    def measurement(self, delay=None):
         """
         Trigger and return measurement from the instrument buffer.
 

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -68,7 +68,9 @@ class Keithley6500(DMM):
 
         # Clip values to upper and lower bounds. DMM likes to crash if set out of bounds
         if val < 1 or val > 1000000:
-            raise ParameterError("Number of samples out of bounds. Must be between 1 and 1000000")
+            raise ParameterError(
+                "Number of samples out of bounds. Must be between 1 and 1000000"
+            )
 
         self._write(f":COUN {val}")
         self._is_error()
@@ -227,7 +229,9 @@ class Keithley6500(DMM):
             else:
                 raise InstrumentError(
                     "Error(s) Returned from DMM\n"
-                    + "\n".join([f"Code: {code}\nMessage:{msg}" for code, msg in errors])
+                    + "\n".join(
+                        [f"Code: {code}\nMessage:{msg}" for code, msg in errors]
+                    )
                 )
 
     def _set_measurement_mode(self, mode, _range=None, suffix=None):
@@ -280,7 +284,9 @@ class Keithley6500(DMM):
         command = None
         if _volt_range:
             # Have to construct an alternative commnad for FREQuency range
-            command = f"; :SENS:FREQ:THR:RANG:AUTO OFF; :SENS:FREQ:THR:RANG {_volt_range}"
+            command = (
+                f"; :SENS:FREQ:THR:RANG:AUTO OFF; :SENS:FREQ:THR:RANG {_volt_range}"
+            )
         self._set_measurement_mode("frequency", suffix=command)
 
     def period(self, _range=None, _volt_range=None):

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -117,7 +117,7 @@ class Keithley6500(DMM):
         self._write("INIT; *WAI")
         self._is_error()
 
-    def measurement(self, delay=True):
+    def measurement(self, delay=None):
         """
         Sets up DMM triggering, creates list of measurements from the read buffer
 

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -1,7 +1,5 @@
 from threading import Lock
-from pyvisa import constants
 from fixate.core.exceptions import InstrumentError, ParameterError
-from fixate.core.common import mode_builder, deprecated
 from fixate.drivers.dmm.helper import DMM
 import time
 
@@ -81,10 +79,10 @@ class Keithley6500(DMM):
         # So just set up a trigger loop. Requires *TRG to be sent to drop it out of the loop (call to remote()).
         self.samples = 1
         self._write("TRIG:LOAD 'EMPTY'")  # Load empty model
-        self._write(f"TRIG:BLOC:MDIG 1, 'defbuffer1', 1")
-        self._write(f"TRIG:BLOC:DEL:CONS 2, 0.1")
+        self._write("TRIG:BLOC:MDIG 1, 'defbuffer1', 1")
+        self._write("TRIG:BLOC:DEL:CONS 2, 0.1")
         self._write("TRIG:BLOC:BRAN:EVEN 3, COMM, 5")
-        self._write(f"TRIG:BLOC:BRAN:ALW 4, 1")
+        self._write("TRIG:BLOC:BRAN:ALW 4, 1")
         self._write("TRIG:BLOC:BUFF:CLE 5")
         self._write("TRAC:CLE")
         self._write("INIT")

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -9,9 +9,8 @@ class Keithley6500(DMM):
     INSTR_TYPE = "VISA"
 
     def __init__(self, instrument, *args, **kwargs):
-        self.measurement_delay = (
-            0.2  # Delay between call to self.measurement() and querying the DMM.
-        )
+        # Delay between call to self.measurement() and querying the DMM.
+        self.measurement_delay = 0.2
         self.instrument = instrument
         instrument.rtscts = 1
         self.lock = Lock()
@@ -122,11 +121,14 @@ class Keithley6500(DMM):
         """
         Sets up DMM triggering, creates list of measurements from the read buffer
 
-        delay: If True, will wait for self.measurement_delay seconds before triggering a measurement.
+        delay: If not set, will wait for self.measurement_delay seconds before triggering a measurement. If set, will wait for delay seconds before triggering a measurement.
         returns: a single value as a float
         """
-        if delay:
-            time.sleep(self.measurement_delay)
+        if delay is None:
+            delay = self.measurement_delay
+
+        if delay > 0:
+            time.sleep(delay)
         return self.measurements()[0]
 
     def measurements(self):

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -9,7 +9,9 @@ class Keithley6500(DMM):
     INSTR_TYPE = "VISA"
 
     def __init__(self, instrument, *args, **kwargs):
-        self.measurement_delay = 0.2 # Delay between call to self.measurement() and querying the DMM.
+        self.measurement_delay = (
+            0.2  # Delay between call to self.measurement() and querying the DMM.
+        )
         self.instrument = instrument
         instrument.rtscts = 1
         self.lock = Lock()
@@ -66,9 +68,7 @@ class Keithley6500(DMM):
 
         # Clip values to upper and lower bounds. DMM likes to crash if set out of bounds
         if val < 1 or val > 1000000:
-            raise ParameterError(
-                "Number of samples out of bounds. Must be between 1 and 1000000"
-            )
+            raise ParameterError("Number of samples out of bounds. Must be between 1 and 1000000")
 
         self._write(f":COUN {val}")
         self._is_error()
@@ -227,9 +227,7 @@ class Keithley6500(DMM):
             else:
                 raise InstrumentError(
                     "Error(s) Returned from DMM\n"
-                    + "\n".join(
-                        [f"Code: {code}\nMessage:{msg}" for code, msg in errors]
-                    )
+                    + "\n".join([f"Code: {code}\nMessage:{msg}" for code, msg in errors])
                 )
 
     def _set_measurement_mode(self, mode, _range=None, suffix=None):
@@ -282,9 +280,7 @@ class Keithley6500(DMM):
         command = None
         if _volt_range:
             # Have to construct an alternative commnad for FREQuency range
-            command = (
-                f"; :SENS:FREQ:THR:RANG:AUTO OFF; :SENS:FREQ:THR:RANG {_volt_range}"
-            )
+            command = f"; :SENS:FREQ:THR:RANG:AUTO OFF; :SENS:FREQ:THR:RANG {_volt_range}"
         self._set_measurement_mode("frequency", suffix=command)
 
     def period(self, _range=None, _volt_range=None):

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -11,6 +11,7 @@ class Keithley6500(DMM):
     INSTR_TYPE = "VISA"
 
     def __init__(self, instrument, *args, **kwargs):
+        self.measurement_delay = 0.2 # Delay between call to self.measurement() and querying the DMM.
         self.instrument = instrument
         instrument.rtscts = 1
         self.lock = Lock()
@@ -117,11 +118,15 @@ class Keithley6500(DMM):
         self._write("INIT; *WAI")
         self._is_error()
 
-    def measurement(self):
+    def measurement(self, delay=True):
         """
         Sets up DMM triggering, creates list of measurements from the read buffer
+
+        delay: If True, will wait for self.measurement_delay seconds before triggering a measurement.
         returns: a single value as a float
         """
+        if delay:
+            time.sleep(self.measurement_delay)
         return self.measurements()[0]
 
     def measurements(self):


### PR DESCRIPTION
Add delay option to DMM driver to help alleviate issues with Keithley DMM compatibility. 
This stems from test script failures due to the Keithley sampling a measurement before the relays (or voltage rails etc) have completely settled. Apparently the Fluke is slower at this so it hasn't been a problem. 

I also removed some dead code and formatted. 

