### PR TITLE
Possible driver manager concept

### DIFF
--- a/src/fixate/__main__.py
+++ b/src/fixate/__main__.py
@@ -13,6 +13,7 @@ from fixate.core.exceptions import SequenceAbort
 from fixate.core.ui import user_info_important, user_serial, user_ok
 from fixate.reporting import register_csv, unregister_csv
 from fixate.ui_cmdline import register_cmd_line, unregister_cmd_line
+from fixate.core.common import TestScript
 import fixate.sequencer
 
 parser = ArgumentParser(
@@ -335,7 +336,7 @@ class FixateWorker:
                 return ReturnCodes.ERROR
 
 
-def retrieve_test_data(test_suite, index):
+def retrieve_test_data(test_suite, index) -> TestScript:
     """
     Tries to retrieve test data from the loaded test_suite module
     :param test_suite: Imported module with tests available
@@ -346,7 +347,7 @@ def retrieve_test_data(test_suite, index):
         data = test_suite.test_data
     except AttributeError:
         # Try legacy API
-        return test_suite.TEST_SEQUENCE
+        return test_suite.TEST_SCRIPT
     try:
         sequence = data[index]
     except KeyError as e:

--- a/src/fixate/drivers/dmm/__init__.py
+++ b/src/fixate/drivers/dmm/__init__.py
@@ -19,7 +19,7 @@ from fixate.drivers.dmm.helper import DMM
 
 def open() -> DMM:
 
-    for DMM in (Fluke8846A, Keithley6500):
+    for driver_class in (Fluke8846A, Keithley6500):
 
         instrument = find_instrument_by_id(DMM.REGEX_ID)
         if instrument is not None:
@@ -32,7 +32,7 @@ def open() -> DMM:
                     f"Unable to open DMM: {instrument.address}"
                 ) from e
             # Instantiate driver with connected instrument
-            driver = DMM(resource)
+            driver = driver_class(resource)
             fixate.drivers.log_instrument_open(driver)
             return driver
     raise InstrumentNotFoundError

--- a/test-script.py
+++ b/test-script.py
@@ -21,8 +21,9 @@ class JigDmm:
 
 @dataclasses.dataclass
 class Jig123DriverManager:
-    dummy: JigDmm = dataclasses.field(default_factory=JigDmm)
-    dmm: dmm.DMM = dataclasses.field(default_factory=dmm.open)
+    dmm: JigDmm = dataclasses.field(default_factory=JigDmm)
+    # This doesn't work right at the moment... not sure why yet.
+    # dmm: dmm.DMM = dataclasses.field(default_factory=dmm.open)
 
 
 class Jig123TestList(TestList[Jig123DriverManager]):

--- a/test-script.py
+++ b/test-script.py
@@ -1,0 +1,72 @@
+import dataclasses
+
+from fixate.core.checks import chk_true
+from fixate.core.common import TestClass, TestList, TestScript
+from fixate.core.ui import user_info
+from fixate.drivers import dmm
+
+
+class JigDmm:
+    """Just for my testing..."""
+    def voltage_dc(self, _range: float) -> None:
+        pass
+
+    def measurement(self) -> float:
+        user_info("Do some measurement!!!")
+        return 0.0
+
+    def close(self):
+        user_info("Closing dummy dmm")
+
+
+@dataclasses.dataclass
+class Jig123DriverManager:
+    dummy: JigDmm = dataclasses.field(default_factory=JigDmm)
+    dmm: dmm.DMM = dataclasses.field(default_factory=dmm.open)
+
+
+class Jig123TestList(TestList[Jig123DriverManager]):
+    pass
+
+
+class Jig123TestClass(TestClass[Jig123DriverManager]):
+    pass
+
+
+class FailTest(Jig123TestClass):
+    def set_up(self, dm: Jig123DriverManager):
+        dm.dmm.voltage_dc(_range=30)
+
+    def test(self, dm: Jig123DriverManager):
+        v = dm.dmm.measurement()
+        user_info(f"voltage measured was {v}")
+        chk_true(False, "force a failure to see test cleanup")
+
+class PassTest(Jig123TestClass):
+    def test(self, dm: Jig123DriverManager):
+        user_info(f"voltage measured was {dm.dmm.measurement()}")
+
+
+
+# New TestScript class bundles a test list with a driver manager. In
+# test_variants.py, we will define TestScript objects instead of top level
+# test lists like we do now. I've used a dataclass for the driver manager,
+# but it could be any class. It is also possible to define a small function
+# to use as the `default_factor` say for a serial port, where we need to use
+# findftdi to get the right port to open.
+
+# Note that this is a bit of a compromise and might end up being a problem.
+# At the moment would be possible for different `drivers` on our standard
+# driver manager to use each other. We can't (easily) control creation order
+# here, so that could run into problems. The behaviour is also slightly
+# different to what we have now were each driver get "automatically" opened
+# when accessed for the first time. With this design the sequence would
+# create the driver manger, calling the default factory of each driver. I'm
+# not sure that is necessarily good or bad. But is subtly different to existing
+# driver managers.
+#
+
+TEST_SCRIPT = TestScript(
+    test_list=Jig123TestList([FailTest(), PassTest()]),
+    dm_type=Jig123DriverManager,
+)


### PR DESCRIPTION
This is pretty scrappy, but mostly trying to test out the big picture idea.

Have a look at `test-script.py`. Here is the general concept:

```python
# 1. Define a class which is your "driver manager"
@dataclasses.dataclass
class Jig123DriverManager:
    dmm: dmm.DMM = dataclasses.field(default_factory=dmm.open)


# 2. TestList and TestClass are generic. You need connect them to the driver manager type
class Jig123TestList(TestList[Jig123DriverManager]):
    pass


class Jig123TestClass(TestClass[Jig123DriverManager]):
    pass

# 3. Define your tests & lists as normal. But now the driver manager will be passed in by the
# sequencer to test, set_up, tear_down, enter and exit. By annotating the dm attribute, you
# get reliable autocomplete in the IDE.
class Test(Jig123TestClass):
    def test(self, dm: Jig123DriverManager):
        value = dm.dmm.measure()
        ...

# 4. Instead of only specifying a top level test list to the sequencer, we will now
# pass in a `TestScript`, which tell the sequencer how to create a driver manager to pass
# into the TestClass/TestList methods.
TEST_SCRIPT = TestScript(
    test_list=Jig123TestList(... Test list goes here ... ),
    dm_type=Jig123DriverManager,
)
```

The doesn't work 100% yet, the example with the "dummy" driver works. obviously we will also need to think about backwards compatibility.