### PR TITLE
Turn warning into errors and fix them

### DIFF
--- a/src/fixate/core/common.py
+++ b/src/fixate/core/common.py
@@ -84,7 +84,7 @@ def match_kwarg(search, keys):
 def sanitise_kwargs(kwargs, repl_kwargs):
     for kw in repl_kwargs:
         # Removes all non character symbols
-        new_kw = re.sub("[^\w]", "", repl_kwargs[kw])
+        new_kw = re.sub(r"[^\w]", "", repl_kwargs[kw])
         kwargs[new_kw] = kwargs.pop(kw)
     return kwargs
 
@@ -128,7 +128,7 @@ def mode_builder(search_dict, repl_kwargs, *args, **kwargs):
     ret_string += mode_builder(search_dict[matches[0]], repl_kwargs, *args, **kwargs)
 
     # Remove the optional '[]' markers
-    ret_string = re.sub("[[\]]", "", ret_string)
+    ret_string = re.sub(r"[[\]]", "", ret_string)
     kwargs = sanitise_kwargs(kwargs, repl_kwargs)
     ret_string = ret_string.format(**kwargs)
     return ret_string
@@ -182,7 +182,7 @@ def unit_scale(str_value, accepted_units=UNITS):
             )
         )
     # Match Decimal and Integer Values
-    p = re.compile("\d+(\.\d+)?")
+    p = re.compile(r"\d+(\.\d+)?")
     num_match = p.search(str_value)
     if num_match:
         num = float(num_match.group())

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,10 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,black,mypy
+envlist = py37,py38,py39,py310,py311,py312,black,mypy
 isolated_build = True
 
 [testenv]
 extras = test
-commands = pytest --junitxml=junit/test-results.xml --cov=fixate --cov-report=xml --cov-report=html -m "not drivertest"
-
-# I've removed the pin on PyDAQmx but going to leave this here for the moment
-# in case I need to put it back.
-# <58.0.0 for PyDAQmx==1.3 which uses 2to3, which was deprecated in 58.0.0
-# Later versions of PyDAQmx fix this, but there are some breaking changes
-# that we need to fix first.
-# deps =
-#     setuptools < 58.0.0
+commands = pytest -W error --junitxml=junit/test-results.xml --cov=fixate --cov-report=xml --cov-report=html -m "not drivertest"
 
 [testenv:build]
 basepython = python3


### PR DESCRIPTION
Pass the `-W error` flag to pytest runs, which makes warnings into errors. This uncovered a few invalid regex strings that have been fixed.