### PR TITLE
add set_dtr and clr_dtr methods needed for J504

### DIFF
--- a/src/fixate/drivers/ftdi.py
+++ b/src/fixate/drivers/ftdi.py
@@ -209,6 +209,12 @@ class FTDI2xx(object):
     def close(self):
         check_return(ftdI2xx.FT_Close(self.handle))
 
+    def set_dtr(self):
+        check_return(ftdI2xx.FT_SetDtr(self.handle))
+
+    def clr_dtr(self):
+        check_return(ftdI2xx.FT_ClrDtr(self.handle))
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
Development of test script for Jig 504 requires DUT MCU to be held in reset whilst checking voltage levels of DUT power supplies prior to programming. The following methods have been added to ftdi.py:

- FT_SetDtr
- FT_ClrDtr

Documentation source: https://ftdichip.com/wp-content/uploads/2020/08/D2XX_Programmers_GuideFT_000071.pdf 