### PR TITLE
Fix #167: Check if stdin is a terminal before calling termios on it

### DIFF
--- a/src/fixate/ui_cmdline/kbhit.py
+++ b/src/fixate/ui_cmdline/kbhit.py
@@ -39,8 +39,7 @@ class KBHit:
         if os.name == "nt":
             pass
 
-        else:
-
+        elif os.isatty(sys.stdin.fileno()):
             # Save the terminal settings
             self.fd = sys.stdin.fileno()
             self.new_term = termios.tcgetattr(self.fd)
@@ -59,7 +58,7 @@ class KBHit:
         if os.name == "nt":
             pass
 
-        else:
+        elif hasattr(self, "old_term"):
             termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.old_term)
 
     def getch(self):


### PR DESCRIPTION
On *nix, check if stdin is a terminal before calling termios on it as those operations fail on a pipe, ie when running pytest.