### PR TITLE
DMM Drivers - NPLC and Min/Max/Avg support

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -9,6 +9,8 @@ Release Date xx/xx/24
 
 New Features
 ############
+- DMM drivers now have a new function to set NPLC (Number of Power Line Cycles) for the DMM.
+- DMM drivers now have a new function to use the DMM's internal statistics function to take multiple measurements and return the mean, minimum and maximum values.
 
 Improvements
 ############

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -116,7 +116,7 @@ class Fluke8846A(DMM):
         automatically samples the DMM for a given number of samples and returns the min, max, and average values
         :param samples: number of samples to take
         :param sample_time: time to wait for the DMM to take the samples
-        return: min, avg, max values as floats
+        return: min, avg, max values as floats in a dictionary
         """
 
         self._write(f"SAMP:COUN {samples}")
@@ -128,7 +128,9 @@ class Fluke8846A(DMM):
         avg_ = self.instrument.query_ascii_values("CALC:AVER:AVER?")[0]
         max_ = self.instrument.query_ascii_values("CALC:AVER:MAX?")[0]
 
-        return min_, avg_, max_
+        values = {"min": min_, "avg": avg_, "max": max_}
+
+        return values
 
     def reset(self):
         """
@@ -359,24 +361,3 @@ class Fluke8846A(DMM):
         # Remove the CONF: from the start of the string
         mode_str = mode_str.replace("CONF:", "")
         return float(self.instrument.query(f"{mode_str}:NPLC?"))
-
-    # context manager for setting NPLC
-    class _nplc_context_manager(object):
-        def __init__(self, dmm, nplc=None):
-            self.dmm = dmm
-            self.nplc = nplc
-            self.original_nplc = self.dmm.get_nplc()
-
-        def __enter__(self):
-            self.dmm.set_nplc(self.nplc)
-
-        # return to default NPLC setting
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            # check if an exception was raised
-            if exc_type is not None or exc_val is not None or exc_tb is not None:
-                return False  # re-raise the exception
-            # continue with the exit process
-            self.dmm.set_nplc(self.original_nplc)
-
-    def nplc(self, nplc=None):
-        return self._nplc_context_manager(self, nplc)

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -128,7 +128,7 @@ class Fluke8846A(DMM):
         avg_ = self.instrument.query_ascii_values("CALC:AVER:AVER?")[0]
         max_ = self.instrument.query_ascii_values("CALC:AVER:MAX?")[0]
 
-        values = {"min": min_, "avg": avg_, "max": max_}
+        values = DMM.MeasurementStats(min=min_, avg=avg_, max=max_)
 
         return values
 

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -50,7 +50,7 @@ class Fluke8846A(DMM):
             "temperature",
             "ftemperature",
         ]
-        self._nplc_settings = [0.02, 0.2, 1, 10, 100]
+        self._nplc_settings = [0.02, 0.2, 1, 10]
         self._default_nplc = 10  # Default NPLC setting as per Fluke 8846A manual
         self._init_string = ""  # Unchanging
 

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -130,6 +130,10 @@ class Fluke8846A(DMM):
 
         values = DMM.MeasurementStats(min=min_, avg=avg_, max=max_)
 
+        # clean up
+        self._write("CALC:STAT OFF")
+        self._write("SAMP:COUN 1")
+
         return values
 
     def reset(self):

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -243,9 +243,9 @@ class Fluke8846A(DMM):
             nplc = self._default_nplc
 
         mode_str = f"{self._modes[self._mode]}"
-        mode_str = mode_str.replace(
-            "CONF:", ""
-        )  # Remove the CONF: from the start of the string
+
+        # Remove the CONF: from the start of the string
+        mode_str = mode_str.replace("CONF:", "")
 
         self._write(f"{mode_str}:NPLC {nplc}")  # e.g. VOLT:DC:NPLC 10
 

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -116,7 +116,7 @@ class Fluke8846A(DMM):
         automatically samples the DMM for a given number of samples and returns the min, max, and average values
         :param samples: number of samples to take
         :param sample_time: time to wait for the DMM to take the samples
-        return: min, avg, max values as floats in a dictionary
+        return: min, avg, max values as floats in a dataclass
         """
 
         self._write(f"SAMP:COUN {samples}")

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -42,6 +42,16 @@ class Fluke8846A(DMM):
             "continuity": "CONF:CONTinuity",
             "diode": "CONF:DIODe",
         }
+        self._nplc_modes = [
+            "resistance",
+            "fresistance",
+            "voltage_dc",
+            "current_dc",
+            "temperature",
+            "ftemperature",
+        ]
+        self._nplc_settings = [0.02, 0.2, 1, 10, 100]
+        self._default_nplc = 10  # Default NPLC setting as per Fluke 8846A manual
         self._init_string = ""  # Unchanging
 
     @property
@@ -221,6 +231,23 @@ class Fluke8846A(DMM):
             ]
         )
         self._is_error()
+
+    def set_nplc(self, nplc=None, reset=False):
+        if nplc not in self._nplc_settings:
+            raise ParameterError(f"Invalid NPLC setting {nplc}")
+
+        if self._mode not in self._nplc_modes:
+            raise ParameterError(f"NPLC setting not available for mode {self._mode}")
+
+        if reset is True or nplc is None:
+            nplc = self._default_nplc
+
+        mode_str = f"{self._modes[self._mode]}"
+        mode_str = mode_str.replace(
+            "CONF:", ""
+        )  # Remove the CONF: from the start of the string
+
+        self._write(f"{mode_str}:NPLC {nplc}")  # e.g. VOLT:DC:NPLC 10
 
     def voltage_ac(self, _range=None):
         self._set_measurement_mode("voltage_ac", _range)

--- a/src/fixate/drivers/dmm/fluke_8846a.py
+++ b/src/fixate/drivers/dmm/fluke_8846a.py
@@ -124,11 +124,11 @@ class Fluke8846A(DMM):
         self._write("CALC:STAT ON")
         self._write("INIT")
         time.sleep(sample_time)
-        _min = self.instrument.query_ascii_values("CALC:AVER:MIN?")[0]
-        _avg = self.instrument.query_ascii_values("CALC:AVER:AVER?")[0]
-        _max = self.instrument.query_ascii_values("CALC:AVER:MAX?")[0]
+        min_ = self.instrument.query_ascii_values("CALC:AVER:MIN?")[0]
+        avg_ = self.instrument.query_ascii_values("CALC:AVER:AVER?")[0]
+        max_ = self.instrument.query_ascii_values("CALC:AVER:MAX?")[0]
 
-        return _min, _avg, _max
+        return min_, avg_, max_
 
     def reset(self):
         """
@@ -251,22 +251,6 @@ class Fluke8846A(DMM):
         )
         self._is_error()
 
-    def set_nplc(self, nplc=None, reset=False):
-        if reset is True or nplc is None:
-            nplc = self._default_nplc
-        elif nplc not in self._nplc_settings:
-            raise ParameterError(f"Invalid NPLC setting {nplc}")
-
-        if self._mode not in self._nplc_modes:
-            raise ParameterError(f"NPLC setting not available for mode {self._mode}")
-
-        mode_str = f"{self._modes[self._mode]}"
-
-        # Remove the CONF: from the start of the string
-        mode_str = mode_str.replace("CONF:", "")
-
-        self._write(f"{mode_str}:NPLC {nplc}")  # e.g. VOLT:DC:NPLC 10
-
     def voltage_ac(self, _range=None):
         self._set_measurement_mode("voltage_ac", _range)
 
@@ -353,3 +337,46 @@ class Fluke8846A(DMM):
             (example: FLUKE, 45, 9080025, 2.0, D2.0)
         """
         return self.instrument.query("*IDN?").strip()
+
+    def set_nplc(self, nplc=None, reset=False):
+        if reset is True or nplc is None:
+            nplc = self._default_nplc
+        elif nplc not in self._nplc_settings:
+            raise ParameterError(f"Invalid NPLC setting {nplc}")
+
+        if self._mode not in self._nplc_modes:
+            raise ParameterError(f"NPLC setting not available for mode {self._mode}")
+
+        mode_str = f"{self._modes[self._mode]}"
+
+        # Remove the CONF: from the start of the string
+        mode_str = mode_str.replace("CONF:", "")
+
+        self._write(f"{mode_str}:NPLC {nplc}")  # e.g. VOLT:DC:NPLC 10
+
+    def get_nplc(self):
+        mode_str = f"{self._modes[self._mode]}"
+        # Remove the CONF: from the start of the string
+        mode_str = mode_str.replace("CONF:", "")
+        return float(self.instrument.query(f"{mode_str}:NPLC?"))
+
+    # context manager for setting NPLC
+    class _nplc_context_manager(object):
+        def __init__(self, dmm, nplc=None):
+            self.dmm = dmm
+            self.nplc = nplc
+            self.original_nplc = self.dmm.get_nplc()
+
+        def __enter__(self):
+            self.dmm.set_nplc(self.nplc)
+
+        # return to default NPLC setting
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            # check if an exception was raised
+            if exc_type is not None or exc_val is not None or exc_tb is not None:
+                return False  # re-raise the exception
+            # continue with the exit process
+            self.dmm.set_nplc(self.original_nplc)
+
+    def nplc(self, nplc=None):
+        return self._nplc_context_manager(self, nplc)

--- a/src/fixate/drivers/dmm/helper.py
+++ b/src/fixate/drivers/dmm/helper.py
@@ -116,9 +116,11 @@ class DMM:
         def __init__(self, dmm, nplc=None):
             self.dmm = dmm
             self.nplc = nplc
-            self.original_nplc = dmm.get_nplc()
+            self.original_nplc = None
 
         def __enter__(self):
+            # store the original NPLC setting
+            self.original_nplc = self.dmm.get_nplc()
             self.dmm.set_nplc(self.nplc)
 
         # return to default NPLC setting

--- a/src/fixate/drivers/dmm/helper.py
+++ b/src/fixate/drivers/dmm/helper.py
@@ -101,3 +101,24 @@ class DMM:
 
     def get_identity(self):
         raise NotImplementedError
+
+    # context manager for setting NPLC
+    class _nplc_context_manager(object):
+        def __init__(self, dmm, nplc=None):
+            self.dmm = dmm
+            self.nplc = nplc
+            self.original_nplc = dmm.get_nplc()
+
+        def __enter__(self):
+            self.dmm.set_nplc(self.nplc)
+
+        # return to default NPLC setting
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            # check if an exception was raised
+            if exc_type is not None or exc_val is not None or exc_tb is not None:
+                return False  # re-raise the exception
+            # continue with the exit process
+            self.dmm.set_nplc(self.original_nplc)
+
+    def nplc(self, nplc=None):
+        return self._nplc_context_manager(self, nplc)

--- a/src/fixate/drivers/dmm/helper.py
+++ b/src/fixate/drivers/dmm/helper.py
@@ -125,10 +125,6 @@ class DMM:
 
         # return to default NPLC setting
         def __exit__(self, exc_type, exc_val, exc_tb):
-            # check if an exception was raised
-            if exc_type:
-                return False  # re-raise the exception
-            # continue with the exit process
             self.dmm.set_nplc(self.original_nplc)
 
     def nplc(self, nplc=None):

--- a/src/fixate/drivers/dmm/helper.py
+++ b/src/fixate/drivers/dmm/helper.py
@@ -124,7 +124,7 @@ class DMM:
         # return to default NPLC setting
         def __exit__(self, exc_type, exc_val, exc_tb):
             # check if an exception was raised
-            if exc_type is not None or exc_val is not None or exc_tb is not None:
+            if exc_type:
                 return False  # re-raise the exception
             # continue with the exit process
             self.dmm.set_nplc(self.original_nplc)

--- a/src/fixate/drivers/dmm/helper.py
+++ b/src/fixate/drivers/dmm/helper.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+
+
 class DMM:
     REGEX_ID = "DMM"
     is_connected = False
@@ -101,6 +104,12 @@ class DMM:
 
     def get_identity(self):
         raise NotImplementedError
+
+    @dataclass
+    class MeasurementStats:
+        min: float
+        max: float
+        avg: float
 
     # context manager for setting NPLC
     class _nplc_context_manager(object):

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -170,7 +170,7 @@ class Keithley6500(DMM):
         self._write("SENS:COUNt 1")
         self._write('TRAC:DEL "TempTable"')
 
-        values = {"min": min_, "avg": avg_, "max": max_}
+        values = DMM.MeasurementStats(min=min_, avg=avg_, max=max_)
 
         return values
 

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -40,14 +40,15 @@ class Keithley6500(DMM):
             "continuity": "CONT",
             "diode": "DIOD",
         }
+        # note: the keithley 6500 also supports changing NPLC for diode measurements, but this has been removed as the fluke does not support it.
         self._nplc_modes = [
             "voltage_dc",
             "current_dc",
             "resistance",
             "fresistance",
-            "diode",
             "temperature",
         ]
+        # note: the keithley supports setting NPLC to any value between 0.0005 and 12 (with 50hz mains power) but for compatibility with the fluke, we only support the following values
         self._nplc_settings = [0.02, 0.2, 1, 10]
         self._nplc_default = 1
         self._init_string = ""  # Unchanging

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -49,6 +49,7 @@ class Keithley6500(DMM):
             "temperature",
         ]
         self._nplc_settings = [0.02, 0.2, 1, 10]
+        self._nplc_default = 1
         self._init_string = ""  # Unchanging
 
     # Adapted for different DMM behaviour
@@ -386,7 +387,11 @@ class Keithley6500(DMM):
 
     def set_nplc(self, nplc=None, reset=False):
         if reset is True or nplc is None:
-            nplc = "DEF"  # keithley supports sending the "DEF" string to reset the NPLC value
+            nplc = self._nplc_default
+            # note: keithley 6500 supports using "DEF" to reset to default NPLC setting
+            # however this sets the NPLC to 0.02 which is not the default setting
+            # the datasheet specifies 1 as the default (and this has been confirmed by resetting the dmm)
+            # so this behaviour is confusing. So we just manually set the default value to 1
         elif nplc not in self._nplc_settings:
             raise ParameterError(f"Invalid NPLC setting {nplc}")
 

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -152,7 +152,7 @@ class Keithley6500(DMM):
         automatically samples the DMM for a given number of samples and returns the min, max, and average values
         :param samples: number of samples to take
         :param sample_time: time to wait for the DMM to take the samples
-        return: min, avg, max values as floats in a dictionary
+        return: min, avg, max values as floats in a dataclass
         """
 
         self._write(f'TRAC:MAKE "TempTable", {samples}')

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -40,7 +40,16 @@ class Keithley6500(DMM):
             "continuity": "CONT",
             "diode": "DIOD",
         }
-
+        self._nplc_modes = [
+            "voltage_dc",
+            "current_dc",
+            "resistance",
+            "fresistance",
+            "diode",
+            "temperature",
+        ]
+        self._nplc_min = 0.0005  # Minimum NPLC setting for the DMM
+        self._nplc_max = 12  # Maximum NPLC setting for the DMM
         self._init_string = ""  # Unchanging
 
     # Adapted for different DMM behaviour
@@ -254,6 +263,19 @@ class Keithley6500(DMM):
         self._write(mode_str)
         self._write(f":COUN {self.samples}")
         self._is_error()
+
+    def set_nplc(self, nplc=None, reset=False):
+        if nplc <= self._nplc_min or nplc >= self._nplc_max:
+            raise ParameterError(f"NPLC setting out of range for Keithley 6500")
+
+        if self._mode not in self._nplc_modes:
+            raise ParameterError(f"NPLC setting not available for mode {self._mode}")
+
+        if reset is True or nplc is None:
+            nplc = "DEF"  # keithley supports sending the "DEF" string to reset the NPLC value
+
+        mode_str = f"{self._modes[self._mode]}"
+        self._write(f":SENS:{mode_str}:NPLC {nplc}")
 
     def voltage_ac(self, _range=None):
         self._set_measurement_mode("voltage_ac", _range)

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -48,8 +48,7 @@ class Keithley6500(DMM):
             "diode",
             "temperature",
         ]
-        self._nplc_min = 0.0005  # Minimum NPLC setting for the DMM
-        self._nplc_max = 12  # Maximum NPLC setting for the DMM
+        self._nplc_settings = [0.02, 0.2, 1, 10]
         self._init_string = ""  # Unchanging
 
     # Adapted for different DMM behaviour
@@ -159,7 +158,7 @@ class Keithley6500(DMM):
         self._write(f"SENS:COUNt {samples}")
 
         # we don't actually want the results, this is just to tell the DMM to start sampling
-        _tmp = self.instrument.query_ascii_values('READ? "TempTable"')[0]
+        _ = self.instrument.query_ascii_values('READ? "TempTable"')
         time.sleep(sample_time)
 
         _avg = self.instrument.query_ascii_values('TRAC:STAT:AVER? "TempTable"')[0]
@@ -292,8 +291,8 @@ class Keithley6500(DMM):
     def set_nplc(self, nplc=None, reset=False):
         if reset is True or nplc is None:
             nplc = "DEF"  # keithley supports sending the "DEF" string to reset the NPLC value
-        elif nplc <= self._nplc_min or nplc >= self._nplc_max:
-            raise ParameterError(f"NPLC setting out of range for Keithley 6500")
+        elif nplc not in self._nplc_settings:
+            raise ParameterError(f"Invalid NPLC setting {nplc}")
 
         if self._mode not in self._nplc_modes:
             raise ParameterError(f"NPLC setting not available for mode {self._mode}")

--- a/src/fixate/drivers/dmm/keithley_6500.py
+++ b/src/fixate/drivers/dmm/keithley_6500.py
@@ -151,7 +151,7 @@ class Keithley6500(DMM):
         automatically samples the DMM for a given number of samples and returns the min, max, and average values
         :param samples: number of samples to take
         :param sample_time: time to wait for the DMM to take the samples
-        return: min, avg, max values as floats
+        return: min, avg, max values as floats in a dictionary
         """
 
         self._write(f'TRAC:MAKE "TempTable", {samples}')
@@ -169,7 +169,9 @@ class Keithley6500(DMM):
         self._write("SENS:COUNt 1")
         self._write('TRAC:DEL "TempTable"')
 
-        return min_, avg_, max_
+        values = {"min": min_, "avg": avg_, "max": max_}
+
+        return values
 
     def reset(self):
         """
@@ -396,24 +398,3 @@ class Keithley6500(DMM):
 
     def get_nplc(self):
         return float(self.instrument.query(f":SENS:{self._modes[self._mode]}:NPLC?"))
-
-    # context manager for setting NPLC
-    class _nplc_context_manager(object):
-        def __init__(self, dmm, nplc=None):
-            self.dmm = dmm
-            self.nplc = nplc
-            self.original_nplc = dmm.get_nplc()
-
-        def __enter__(self):
-            self.dmm.set_nplc(self.nplc)
-
-        # return to default NPLC setting
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            # check if an exception was raised
-            if exc_type is not None or exc_val is not None or exc_tb is not None:
-                return False  # re-raise the exception
-            # continue with the exit process
-            self.dmm.set_nplc(self.original_nplc)
-
-    def nplc(self, nplc=None):
-        return self._nplc_context_manager(self, nplc)

--- a/test/drivers/test_fluke_8846A.py
+++ b/test/drivers/test_fluke_8846A.py
@@ -363,12 +363,12 @@ def test_min_avg_max(dmm, rm, funcgen):
     dmm.voltage_dc()
     dmm.set_nplc(nplc=0.02)
     values = dmm.min_avg_max(995, 1.1)
-    min_ = values["min"]
-    avg_ = values["avg"]
-    max_ = values["max"]
+    min_val = values.min
+    avg_val = values.avg
+    max_val = values.max
 
     # does not guarantee that there is any input to the DMM so we can't guarantee that the min, avg, max are different
-    assert min_ <= avg_ <= max_
+    assert min_val <= avg_val <= max_val
 
     v = 50e-3
     f = 50
@@ -381,11 +381,11 @@ def test_min_avg_max(dmm, rm, funcgen):
     time.sleep(0.5)
 
     values = dmm.min_avg_max(995, 1.1)
-    min_ = values["min"]
-    avg_ = values["avg"]
-    max_ = values["max"]
+    min_val = values.min
+    avg_val = values.avg
+    max_val = values.max
 
-    assert min_ < avg_ < max_
+    assert min_val < avg_val < max_val
 
 
 @pytest.mark.drivertest

--- a/test/drivers/test_fluke_8846A.py
+++ b/test/drivers/test_fluke_8846A.py
@@ -324,6 +324,9 @@ def test_measurement_diode(funcgen, dmm, rm):
         ("resistance"),
         ("fresistance"),
         pytest.param(
+            "diode", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
             "voltage_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
         ),
         pytest.param(
@@ -358,6 +361,9 @@ def test_get_nplc(mode, dmm):
         ("current_dc"),
         ("resistance"),
         ("fresistance"),
+        pytest.param(
+            "diode", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
         pytest.param(
             "voltage_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
         ),
@@ -401,6 +407,9 @@ def test_set_nplc(mode, dmm):
         ("current_dc"),
         ("resistance"),
         ("fresistance"),
+        pytest.param(
+            "diode", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
         pytest.param(
             "voltage_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
         ),

--- a/test/drivers/test_fluke_8846A.py
+++ b/test/drivers/test_fluke_8846A.py
@@ -317,6 +317,58 @@ def test_measurement_diode(funcgen, dmm, rm):
 
 
 @pytest.mark.drivertest
+def test_get_nplc(dmm):
+    query = dmm.get_nplc()
+    assert query == pytest.approx(10)
+
+
+@pytest.mark.drivertest
+def test_set_nplc(dmm):
+    dmm.voltage_dc()
+    dmm.set_nplc(nplc=1)
+    query = dmm.get_nplc()
+    assert query == pytest.approx(1)
+
+    dmm.set_nplc(reset=True)  # Set to default
+    query = dmm.get_nplc()
+    assert query == pytest.approx(10)
+
+    # invalid nplc value
+    with pytest.raises(ParameterError):
+        dmm.set_nplc(nplc=999)
+
+    # invalid mode
+    dmm.voltage_ac()
+    with pytest.raises(ParameterError):
+        dmm.set_nplc(nplc=1)
+
+
+@pytest.mark.drivertest
+def test_nplc_context_manager(dmm):
+    dmm.voltage_dc()
+    dmm.set_nplc(nplc=0.02)
+    with dmm.nplc(1):
+        query = dmm.get_nplc()
+        assert query == pytest.approx(1)
+    query = dmm.get_nplc()
+    assert query == pytest.approx(0.02)
+
+    with pytest.raises(ZeroDivisionError):
+        with dmm.nplc(1):
+            _ = 1 / 0  # make sure exception is not swallowed
+
+
+@pytest.mark.drivertest
+def test_min_avg_max(dmm):
+    dmm.voltage_dc()
+    dmm.set_nplc(nplc=0.02)
+    min_, avg_, max_ = dmm.min_avg_max(995, 1.1)
+
+    # does not guarantee that there is any input to the DMM so we can't guarantee that the min, avg, max are different
+    assert min_ <= avg_ <= max_
+
+
+@pytest.mark.drivertest
 def test_get_identity(dmm):
     iden = dmm.get_identity()
     assert "FLUKE,8846A" in iden

--- a/test/drivers/test_fluke_8846A.py
+++ b/test/drivers/test_fluke_8846A.py
@@ -359,13 +359,33 @@ def test_nplc_context_manager(dmm):
 
 
 @pytest.mark.drivertest
-def test_min_avg_max(dmm):
+def test_min_avg_max(dmm, rm, funcgen):
     dmm.voltage_dc()
     dmm.set_nplc(nplc=0.02)
-    min_, avg_, max_ = dmm.min_avg_max(995, 1.1)
+    values = dmm.min_avg_max(995, 1.1)
+    min_ = values["min"]
+    avg_ = values["avg"]
+    max_ = values["max"]
 
     # does not guarantee that there is any input to the DMM so we can't guarantee that the min, avg, max are different
     assert min_ <= avg_ <= max_
+
+    v = 50e-3
+    f = 50
+    rm.mux.connectionMap("DMM_SIG")
+    funcgen.channel1.waveform.sin()
+    funcgen.channel1.vrms(v)
+    funcgen.channel1.frequency(f)
+    funcgen.channel1(True)
+
+    time.sleep(0.5)
+
+    values = dmm.min_avg_max(995, 1.1)
+    min_ = values["min"]
+    avg_ = values["avg"]
+    max_ = values["max"]
+
+    assert min_ < avg_ < max_
 
 
 @pytest.mark.drivertest

--- a/test/drivers/test_keithley_6500.py
+++ b/test/drivers/test_keithley_6500.py
@@ -329,9 +329,11 @@ def test_measurement_diode(funcgen, dmm, rm):
     [
         ("voltage_dc"),
         ("current_dc"),
-        ("diode"),
         ("resistance"),
         ("fresistance"),
+        pytest.param(
+            "diode", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
         pytest.param(
             "voltage_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
         ),
@@ -365,9 +367,11 @@ def test_get_nplc(mode, dmm):
     [
         ("voltage_dc"),
         ("current_dc"),
-        ("diode"),
         ("resistance"),
         ("fresistance"),
+        pytest.param(
+            "diode", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
         pytest.param(
             "voltage_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
         ),
@@ -409,9 +413,11 @@ def test_set_nplc(mode, dmm):
     [
         ("voltage_dc"),
         ("current_dc"),
-        ("diode"),
         ("resistance"),
         ("fresistance"),
+        pytest.param(
+            "diode", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
         pytest.param(
             "voltage_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
         ),

--- a/test/drivers/test_keithley_6500.py
+++ b/test/drivers/test_keithley_6500.py
@@ -324,17 +324,73 @@ def test_measurement_diode(funcgen, dmm, rm):
     assert meas == pytest.approx(TEST_DIODE, abs=TEST_DIODE_TOL)
 
 
+@pytest.mark.parametrize(
+    "mode",
+    [
+        ("voltage_dc"),
+        ("current_dc"),
+        ("diode"),
+        ("resistance"),
+        ("fresistance"),
+        pytest.param(
+            "voltage_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "current_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "period", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "frequency", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "capacitance", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "continuity", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+    ],
+)
 @pytest.mark.drivertest
-def test_get_nplc(dmm):
-    dmm.voltage_dc()
+def test_get_nplc(mode, dmm):
+    getattr(dmm, mode)()
     dmm.set_nplc(reset=True)
     query = dmm.get_nplc()
     assert query == pytest.approx(1)
 
 
+@pytest.mark.parametrize(
+    "mode",
+    [
+        ("voltage_dc"),
+        ("current_dc"),
+        ("diode"),
+        ("resistance"),
+        ("fresistance"),
+        pytest.param(
+            "voltage_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "current_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "period", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "frequency", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "capacitance", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "continuity", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+    ],
+)
 @pytest.mark.drivertest
-def test_set_nplc(dmm):
-    dmm.voltage_dc()
+def test_set_nplc(mode, dmm):
+    getattr(dmm, mode)()
     dmm.set_nplc(nplc=10)
     query = dmm.get_nplc()
     assert query == pytest.approx(10)
@@ -347,15 +403,39 @@ def test_set_nplc(dmm):
     with pytest.raises(ParameterError):
         dmm.set_nplc(nplc=999)
 
-    # invalid mode
-    dmm.voltage_ac()
-    with pytest.raises(ParameterError):
-        dmm.set_nplc(nplc=1)
 
-
+@pytest.mark.parametrize(
+    "mode",
+    [
+        ("voltage_dc"),
+        ("current_dc"),
+        ("diode"),
+        ("resistance"),
+        ("fresistance"),
+        pytest.param(
+            "voltage_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "current_ac", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "period", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "frequency", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "capacitance", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+        pytest.param(
+            "continuity", marks=pytest.mark.xfail(raises=ParameterError, strict=True)
+        ),
+    ],
+)
 @pytest.mark.drivertest
-def test_nplc_context_manager(dmm):
-    dmm.voltage_dc()
+def test_nplc_context_manager(mode, dmm):
+    getattr(dmm, mode)()
+
     dmm.set_nplc(nplc=0.2)
     with dmm.nplc(1):
         query = dmm.get_nplc()
@@ -368,18 +448,25 @@ def test_nplc_context_manager(dmm):
             _ = 1 / 0  # make sure exception is not swallowed
 
 
+@pytest.mark.parametrize(
+    "mode, samples, nplc",
+    [
+        ("voltage_ac", 10, None),
+        ("voltage_dc", 995, 0.02),
+        ("current_dc", 995, 0.02),
+        ("current_ac", 10, None),
+        ("period", 10, None),
+        ("frequency", 10, None),
+    ],
+)
 @pytest.mark.drivertest
-def test_min_avg_max(dmm, rm, funcgen):
-    dmm.voltage_dc()
-    dmm.set_nplc(nplc=0.02)
+def test_min_avg_max(mode, samples, nplc, dmm, rm, funcgen):
+    # dmm.voltage_dc()
+    getattr(dmm, mode)()
 
-    values = dmm.min_avg_max(995, 1.1)
-    min_val = values.min
-    avg_val = values.avg
-    max_val = values.max
-
-    # does not guarantee that there is any input to the DMM so we can't guarantee that the min, avg, max are different
-    assert min_val <= avg_val <= max_val
+    # only set nplc when able (depends on mode)
+    if nplc:
+        dmm.set_nplc(nplc=nplc)
 
     v = 50e-3
     f = 50
@@ -391,12 +478,39 @@ def test_min_avg_max(dmm, rm, funcgen):
 
     time.sleep(0.5)
 
-    values = dmm.min_avg_max(995, 1.1)
+    values = dmm.min_avg_max(samples, 1.1)
     min_val = values.min
     avg_val = values.avg
     max_val = values.max
 
     assert min_val < avg_val < max_val
+
+    v = 100e-3
+    f = 60
+    funcgen.channel1.vrms(v)
+    funcgen.channel1.frequency(f)
+    time.sleep(0.5)
+
+    values = dmm.min_avg_max(samples, 1.1)
+    min_val2 = values.min
+    avg_val2 = values.avg
+    max_val2 = values.max
+
+    assert min_val2 < avg_val2 < max_val2
+
+    # check if values from the two runs are different
+    # We can only really do this for certain modes and the checks depend on the mode
+    if mode == "voltage_dc":
+        assert min_val2 < min_val
+        assert max_val2 > max_val
+
+    if mode == "frequency":
+        assert min_val2 > min_val
+        assert max_val2 > max_val
+
+    if mode == "period":
+        assert min_val2 < min_val
+        assert max_val2 < max_val
 
 
 @pytest.mark.drivertest

--- a/test/drivers/test_keithley_6500.py
+++ b/test/drivers/test_keithley_6500.py
@@ -372,13 +372,14 @@ def test_nplc_context_manager(dmm):
 def test_min_avg_max(dmm, rm, funcgen):
     dmm.voltage_dc()
     dmm.set_nplc(nplc=0.02)
+
     values = dmm.min_avg_max(995, 1.1)
-    min_ = values["min"]
-    avg_ = values["avg"]
-    max_ = values["max"]
+    min_val = values.min
+    avg_val = values.avg
+    max_val = values.max
 
     # does not guarantee that there is any input to the DMM so we can't guarantee that the min, avg, max are different
-    assert min_ <= avg_ <= max_
+    assert min_val <= avg_val <= max_val
 
     v = 50e-3
     f = 50
@@ -391,11 +392,11 @@ def test_min_avg_max(dmm, rm, funcgen):
     time.sleep(0.5)
 
     values = dmm.min_avg_max(995, 1.1)
-    min_ = values["min"]
-    avg_ = values["avg"]
-    max_ = values["max"]
+    min_val = values.min
+    avg_val = values.avg
+    max_val = values.max
 
-    assert min_ < avg_ < max_
+    assert min_val < avg_val < max_val
 
 
 @pytest.mark.drivertest


### PR DESCRIPTION
Add ability to configure NPLC on a driver level in both the Fluke and Keithley DMM drivers

Added a function to have the drivers sample x times and then return the minimum, maximum and average of the samples