### PR TITLE
Fix issue where a non-boolean variable passed into a testclass would skip the test

### DIFF
--- a/src/fixate/core/common.py
+++ b/src/fixate/core/common.py
@@ -423,7 +423,12 @@ class TestClass:
     skip_on_fail = False
 
     def __init__(self, skip=False):
-        self.skip = skip
+        # Explicitly check if skip is True (and only true) to avoid the case where skip is set to a non-boolean value
+        if skip is True:
+            self.skip = True
+        else:
+            self.skip = False
+
         if not self.test_desc:
             try:
                 doc_string = [


### PR DESCRIPTION
In a test script we were accidentally passing a variable that was not consumed by the function and therefore was passed to the parent class (the testclass) this would then be interpreted as the "skip" variable. The check in sequencer.py does not check if the value is a boolean.

This could result in a code mistake in a test script "silently" skipping a test without being noticed. Unless you go look at the logs.

![image](https://github.com/user-attachments/assets/8412a093-daff-4269-a766-83661ef53396)
![image](https://github.com/user-attachments/assets/d3d648eb-18ce-499f-a704-aaa477689320)
