### PR TITLE
Fix for DSOX1202G hang bug

### DIFF
--- a/src/fixate/drivers/dso/agilent_mso_x.py
+++ b/src/fixate/drivers/dso/agilent_mso_x.py
@@ -547,7 +547,7 @@ class MSO_X_3000(DSO):
         # Clear status registers (CLS)
         # enable the trigger mask in the event register (SRE)
         # operation complete (OPC)
-        self.instrument.query(":STOP;*CLS;*SRE 1;*OPC?")
+        self.instrument.write(":STOP;*CLS")
         self._store["time_base_wait"] = (
             self.instrument.query_ascii_values(":TIM:RANG?")[0]
             + self.instrument.query_ascii_values(":TIM:POS?")[0]
@@ -567,7 +567,7 @@ class MSO_X_3000(DSO):
 
     def run(self):
         self._triggers_read = 0
-        self.query(":STOP;*CLS;*SRE 1;*OPC?")
+        self.query(":STOP;*CLS")
         # Currently we're not using events. wait_on_trigger is polling. The current implementation
         # doesn't work when using a LAN connection to the instrument, so we will comment out for now
         # self.instrument.enable_event(visa.constants.EventType.service_request, visa.constants.VI_QUEUE)


### PR DESCRIPTION
This PR fixes an issue where the driver for DSOX1102G hangs when used with the supposedly compatible DSOX1202G. This patch has been tested via `python -m pytest .\test\drivers\test_keysight_DSOX1102G.py`. This does not seem to introduce any regressions for the DSOX1102G and fixes the hang issue in the DSOX1202G as per the test suite. 

the `*SPC 1` section of the query in run and single causes the DSOX1202G to hang - it seems to do this as the SPC register is a interrupt event mask and when set to 1 will mask all but trigger events off causing the buttons to become unresponsive. This can be seen on page 126 of the programmer's manual.