### PR TITLE
Fix/dsox1202G hangfix

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -3,6 +3,12 @@ Release Notes
 ==================================
 
 *************
+Version 0.6.5
+*************
+Release Date 01/08/2025
+- Bug fix for DSOX1202G where it would appear to hang the program and scope
+
+*************
 Version 0.6.4
 *************
 Release Date 14/01/25

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -5,8 +5,11 @@ Release Notes
 *************
 Version 0.6.5
 *************
-Release Date 01/08/2025
-- Bug fix for DSOX1202G where it would appear to hang the program and scope
+Release Date 01/08/25
+
+Improvements
+############
+- Fix bug where DSOX1202G appeared to hang both the program and scope
 
 *************
 Version 0.6.4

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -5,7 +5,7 @@ Release Notes
 *************
 Version 0.6.5
 *************
-Release Date 01/08/25
+Release Date xx-xx-xxxx
 
 Improvements
 ############

--- a/src/fixate/drivers/dso/agilent_mso_x.py
+++ b/src/fixate/drivers/dso/agilent_mso_x.py
@@ -545,8 +545,6 @@ class MSO_X_3000(DSO):
         self._raise_if_error()  # Raises if any errors were made during setup
         # Stop
         # Clear status registers (CLS)
-        # enable the trigger mask in the event register (SRE)
-        # operation complete (OPC)
         self.instrument.write(":STOP;*CLS")
         self._store["time_base_wait"] = (
             self.instrument.query_ascii_values(":TIM:RANG?")[0]

--- a/src/fixate/drivers/dso/agilent_mso_x.py
+++ b/src/fixate/drivers/dso/agilent_mso_x.py
@@ -547,7 +547,7 @@ class MSO_X_3000(DSO):
         # Clear status registers (CLS)
         # enable the trigger mask in the event register (SRE)
         # operation complete (OPC)
-        self.instrument.query(":STOP;*CLS;*SRE 1;*OPC?")
+        self.instrument.write(":STOP;*CLS")
         self._store["time_base_wait"] = (
             self.instrument.query_ascii_values(":TIM:RANG?")[0]
             + self.instrument.query_ascii_values(":TIM:POS?")[0]
@@ -567,7 +567,7 @@ class MSO_X_3000(DSO):
 
     def run(self):
         self._triggers_read = 0
-        self.query(":STOP;*CLS;*SRE 1;*OPC?")
+        self.query(":STOP;*CLS")
         # Currently we're not using events. wait_on_trigger is polling. The current implementation
         # doesn't work when using a LAN connection to the instrument, so we will comment out for now
         # self.instrument.enable_event(visa.constants.EventType.service_request, visa.constants.VI_QUEUE)

--- a/src/fixate/drivers/dso/agilent_mso_x.py
+++ b/src/fixate/drivers/dso/agilent_mso_x.py
@@ -567,7 +567,7 @@ class MSO_X_3000(DSO):
 
     def run(self):
         self._triggers_read = 0
-        self.query(":STOP;*CLS")
+        self.write(":STOP;*CLS")
         # Currently we're not using events. wait_on_trigger is polling. The current implementation
         # doesn't work when using a LAN connection to the instrument, so we will comment out for now
         # self.instrument.enable_event(visa.constants.EventType.service_request, visa.constants.VI_QUEUE)


### PR DESCRIPTION
Second times the charm;
First pull request was (probably) fine -I was just checked out to main rather than fix/DSOX1202G-hangfix

Replaced `.query(":STOP;*CLS;*SRE 1;*OPC?")` with `.write(":STOP;*CLS")` and it fixes the issue with the DSOX1202G hanging. All tests pass for both the DSOX1202G as well as the DSOX1102G.

DSOX1202G: 67 passed, 1 xfailed, 1 xpassed in 271.40s
DSOX1102G: 67 passed, 2 xfailed in 372.80s
