### PR TITLE
Fixing issues in driver tests

### DIFF
--- a/test/drivers/test_fluke_8846A.py
+++ b/test/drivers/test_fluke_8846A.py
@@ -9,7 +9,7 @@ load_config()  # Load fixate config file
 # Test values for measurement functions:
 # These are mostly defined either by J413 or an arbitrary number I picked.
 TEST_RESISTANCE = 100  # Resistance in loopback jig for testing
-TEST_RESISTANCE_TOL = 1  # 1 Ohm absolute tolerance
+TEST_RESISTANCE_TOL = 5  # 1 Ohm absolute tolerance
 TEST_CAPACITANCE = 4.7e-6  # Capacitance in loopback jig for testing
 TEST_CAPACITANCE_TOL = 0.5e-6
 TEST_VOLTAGE_DC = 100e-3
@@ -481,7 +481,7 @@ def test_min_avg_max(mode, samples, nplc, dmm, rm, funcgen):
     avg_val = values.avg
     max_val = values.max
 
-    assert min_val < avg_val < max_val
+    assert min_val <= avg_val <= max_val
 
     v = 100e-3
     f = 60
@@ -494,7 +494,7 @@ def test_min_avg_max(mode, samples, nplc, dmm, rm, funcgen):
     avg_val2 = values.avg
     max_val2 = values.max
 
-    assert min_val2 < avg_val2 < max_val2
+    assert min_val2 <= avg_val2 <= max_val2
 
     # check if values from the two runs are different
     # We can only really do this for certain modes and the checks depend on the mode

--- a/test/drivers/test_keithley_6500.py
+++ b/test/drivers/test_keithley_6500.py
@@ -9,7 +9,7 @@ load_config()  # Load fixate config file
 # Test values for measurement functions:
 # These are mostly defined either by J413 or an arbitrary number I picked.
 TEST_RESISTANCE = 100  # Resistance in loopback jig for testing
-TEST_RESISTANCE_TOL = 1  # 1 Ohm absolute tolerance
+TEST_RESISTANCE_TOL = 5  # 1 Ohm absolute tolerance
 TEST_CAPACITANCE = 4.7e-6  # Capacitance in loopback jig for testing
 TEST_CAPACITANCE_TOL = 0.5e-6
 TEST_VOLTAGE_DC = 100e-3
@@ -57,7 +57,7 @@ def test_reset(dmm):
         ("capacitance", "CAP"),
         ("continuity", "CONT"),
         ("diode", "DIOD"),
-        ("temperature", "TEMP"),
+        pytest.param("temperature", "TEMP", marks=pytest.mark.xfail),
         pytest.param("ftemperature", "TEMP", marks=pytest.mark.xfail),
     ],
 )
@@ -489,7 +489,7 @@ def test_min_avg_max(mode, samples, nplc, dmm, rm, funcgen):
     avg_val = values.avg
     max_val = values.max
 
-    assert min_val < avg_val < max_val
+    assert min_val <= avg_val <= max_val
 
     v = 100e-3
     f = 60
@@ -502,7 +502,7 @@ def test_min_avg_max(mode, samples, nplc, dmm, rm, funcgen):
     avg_val2 = values.avg
     max_val2 = values.max
 
-    assert min_val2 < avg_val2 < max_val2
+    assert min_val2 <= avg_val2 <= max_val2
 
     # check if values from the two runs are different
     # We can only really do this for certain modes and the checks depend on the mode

--- a/test/drivers/test_siglent_spd_3303X.py
+++ b/test/drivers/test_siglent_spd_3303X.py
@@ -154,7 +154,7 @@ def test_measure_voltage(pps, channel, query, voltage):
     time.sleep(1)  # Slow PPS again
     v = ch.measure.voltage()
     ch(False)  # Channel ON
-    assert float(v) == pytest.approx(voltage, abs=10e-3)
+    assert float(v) == pytest.approx(voltage, abs=50e-3)
 
 
 # Need to use the patch jig to test any current other than 0.


### PR DESCRIPTION
Changed resistance tolerances in keithley 6500 and fluke 8846A tests from 1 ohm to 5 to account for the fact that it is measuring a 100 ohm resistor, fixing it complaining that it got 102 ohms on a two-wire measurement when it expected 100.

Fixed handling of floating-point measurements in keithley 6500 and fluke 8846A tests, changing `min < avg < max` to `min <= avg <= max`.

Marked temperature test in keithley 6500 as xfail. This is to preserve consistency with the fluke 8846A tests as well as eliminate testing a feature that is not used nor supported.

Changed tolerance in Siglent SPD3303X driver voltage test from 10 mV to 50 mV as that is the limit of the devices precision as guaranteed by Siglent anyway.
