### PR TITLE
Mux checks

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -20,6 +20,7 @@ Improvements
 - Sequencer logic now handles exceptions raised on sequence abort. GUI will no longer hang when a test raises an exception during a test abort. 
 - Fix bug where DSOX1202G appeared to hang both the program and scope
 - LCR Driver now supports instruments reporting as Keysight or Agilent. Newer models of the LCR meter report as Keysight, whereas older models report as Agilent. 
+- Jig switching will now raise an error when pins are not unique across muxes
 
 *************
 Version 0.6.4

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -20,7 +20,8 @@ Improvements
 - Sequencer logic now handles exceptions raised on sequence abort. GUI will no longer hang when a test raises an exception during a test abort. 
 - Fix bug where DSOX1202G appeared to hang both the program and scope
 - LCR Driver now supports instruments reporting as Keysight or Agilent. Newer models of the LCR meter report as Keysight, whereas older models report as Agilent. 
-- Jig switching will now raise an error when pins are not unique across muxes
+- Jig switching will now raise an error when pins are not unique across muxes. Requirement for pin_list has been dropped when not using map_tree due to issue
+  where pins would be set but never cleared when a pin was defined in the mux signals but not in the mux pins.
 
 *************
 Version 0.6.4

--- a/examples/jig_driver.py
+++ b/examples/jig_driver.py
@@ -14,7 +14,6 @@ from fixate import (
 
 
 class MuxOne(VirtualMux):
-    pin_list = ("x0", "x1", "x2")
     map_list = (
         ("sig1", "x0"),
         ("sig2", "x1"),

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -237,10 +237,23 @@ class VirtualMux:
         elif hasattr(self, "map_list"):
             pin_set = set()
             signal_map = {}
-            for sig, *pins in self.map_list:
-                pin_set.update(pins)
-                signal_map[sig] = frozenset(pins)
-            return signal_map, frozenset(pin_set)
+            # so great think about the unpack operator (*) is that it gives you a list of items
+            # which means that a string, or sequence of strings look the same as a sequence of sequences of strings
+            # when unpacked this way
+            # filter out these edge cases.
+            # if you want to have a one signal mux, then use a virtual switch instead,
+            # or use the correct definition of map_list
+            if isinstance(self.map_list, str) or all(
+                isinstance(item, str) for item in self.map_list
+            ):
+                raise ValueError(
+                    "map_list should be in the form (('sig1', 'pin1', 'pin2',...)\n('sig2', 'pin3', 'pin4',...)\n...)"
+                )
+            else:
+                for sig, *pins in self.map_list:
+                    pin_set.update(pins)
+                    signal_map[sig] = frozenset(pins)
+                return signal_map, frozenset(pin_set)
         else:
             raise ValueError(
                 "VirtualMux subclass must define either map_tree or map_list"

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -230,10 +230,11 @@ class VirtualMux:
         """
         if hasattr(self, "map_tree"):
             if not hasattr(self, "pin_list"):
-                raise ValueError("pin_list must not be None if defining map_tree")
-            return self._map_tree(
-                self.map_tree, self.pin_list, fixed_pins=frozenset()
-            ), frozenset(self.pin_list)
+                raise ValueError("must include pin_list if defining map_tree")
+            else:
+                return self._map_tree(
+                    self.map_tree, self.pin_list, fixed_pins=frozenset()
+                ), frozenset(self.pin_list)
         elif hasattr(self, "map_list"):
             pin_set = set()
             signal_map = {}

--- a/test/test_switching.py
+++ b/test/test_switching.py
@@ -631,3 +631,17 @@ def test_duplicate_pins_raise():
     # overlap of pins is bad, mux3 can control mux1
     with pytest.raises(ValueError):
         JigDriver(BadGroup, [handler])
+
+
+def test_map_tree_missing_pin_list_raises():
+    class GoodTree(VirtualMux):
+        pin_list = "1"
+        map_tree = ("a", "b")
+
+    GoodTree()
+
+    class BadTree(VirtualMux):
+        map_tree = ("a", "b")
+
+    with pytest.raises(ValueError):
+        BadTree()

--- a/test/test_switching.py
+++ b/test/test_switching.py
@@ -551,7 +551,7 @@ def test_jig_driver_with_unknown_pins():
 
     class Mux(VirtualMux):
         pin_list = ("x0", "x1")  # "x1" isn't in either handler
-        map_list = ("sig1", "x1")
+        map_list = (("sig1", "x1"),)
 
     class Group(MuxGroup):
         def __init__(self):

--- a/test/test_switching.py
+++ b/test/test_switching.py
@@ -592,3 +592,42 @@ def test_pin_update_or():
         2.0,
     )
     assert expected == a | b
+
+
+@pytest.mark.parametrize("bad_map_list", ("single_string", ("tuple", "of", "strings")))
+def test_unsupported_map_lists_raise(bad_map_list):
+    class Mux(VirtualMux):
+        map_list = bad_map_list
+
+    with pytest.raises(ValueError):
+        Mux()
+
+
+def test_duplicate_pins_raise():
+    handler = AddressHandler(("x0", "x1"))
+
+    class Mux1(VirtualMux):
+        map_list = (("sig1", "x0"),)
+
+    class Mux2(VirtualMux):
+        map_list = (("sig2", "x1"),)
+
+    class Mux3(VirtualMux):
+        map_list = (("sig3", "x0", "x1"),)
+
+    class GoodGroup(MuxGroup):
+        def __init__(self):
+            self.mux1 = Mux1()
+            self.mux2 = Mux2()
+
+    class BadGroup(MuxGroup):
+        def __init__(self):
+            self.mux1 = Mux1()
+            self.mux3 = Mux3()
+
+    # this is ok
+    JigDriver(GoodGroup, [handler])
+
+    # overlap of pins is bad, mux3 can control mux1
+    with pytest.raises(ValueError):
+        JigDriver(BadGroup, [handler])


### PR DESCRIPTION
Remove requirement to have both pin_list and pin_map which had issues in the new switching module if pins were missing from the list.

Add check that pins are unique across muxes.