### PR TITLE
Fix file export in waveform values

### DIFF
--- a/src/fixate/drivers/dso/agilent_mso_x.py
+++ b/src/fixate/drivers/dso/agilent_mso_x.py
@@ -757,7 +757,7 @@ class MSO_X_3000(DSO):
             with open(file_name, "w") as f:
                 f.write("x,y\n")
                 for x_val, y_val in zip(x, y):
-                    f.write(f"{x_val},{y_val}")
+                    f.write(f"{x_val},{y_val}\n")
 
         elif file_name and file_type == "bin":
             raise NotImplementedError("Binary Output not implemented")


### PR DESCRIPTION
I forgot a \n on the csv line write.
When exporting the data to a file, you end up with one big long line separated by commas instead of many lines.