### PR TITLE
Fix ret_value checks

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -25,6 +25,7 @@ Improvements
 - Created a new FixateError base class for all exceptions raised by fixate to use. It inherits from Exception instead of BaseExcepetion to improve error handling.
 - DSO Driver function 'waveform_values' now returns a single channels x and y data as two separate lists, without re-acquiring the signal. This function should
   now be called after performing signal acquisition.
+- Fix user input validation. Inputting a float value of 0.0 or 0 now works as expected.
 
 *************
 Version 0.6.4

--- a/src/fixate/ui_cmdline/cmd_line.py
+++ b/src/fixate/ui_cmdline/cmd_line.py
@@ -184,7 +184,7 @@ def _user_choices(msg, q, choices, target, attempts=5):
         print("\a")
         ret_val = input(reformat_text(msg + choicesstr))
         ret_val = target(ret_val, choices)
-        if ret_val:
+        if ret_val is not None:
             q.put(("Result", ret_val))
             return
     q.put(
@@ -227,7 +227,7 @@ def _user_input(msg, q, target=None, attempts=5, kwargs=None):
             q.put(ret_val)
             return
         ret_val = target(ret_val, **kwargs)
-        if ret_val:
+        if ret_val is not None:
             q.put(("Result", ret_val))
             return
     # Display failure of target and send exception

--- a/src/fixate/ui_gui_qt/ui_gui_qt.py
+++ b/src/fixate/ui_gui_qt/ui_gui_qt.py
@@ -780,7 +780,7 @@ class FixateGUI(QtWidgets.QMainWindow, layout.Ui_FixateUI):
             # This will change based on the interface
             ret_val = self.gui_user_input(self.reformat_text(msg), choices)
             ret_val = target(ret_val, choices)
-            if ret_val:
+            if ret_val is not None:
                 q.put(("Result", ret_val))
                 return
         q.put(
@@ -821,7 +821,7 @@ class FixateGUI(QtWidgets.QMainWindow, layout.Ui_FixateUI):
                 q.put(ret_val)
                 return
             ret_val = target(ret_val, **kwargs)
-            if ret_val:
+            if ret_val is not None:
                 q.put(("Result", ret_val))
                 return
         # Display failure of target and send exception


### PR DESCRIPTION
Bjorn pointed out that the get float function does not work when given 0.0 or 0 as a value. 
Investigation shows that the return value checks simply ``is ret_val`` which evaluates to false on 0.0 as its a falsy value.

I have updated the implementation in the ui to explicitly check that ret_val is not None instead. 