### PR TITLE
Simple typed mux

### DIFF
--- a/examples/jig_driver.py
+++ b/examples/jig_driver.py
@@ -65,20 +65,20 @@ jig.mux.mux_three(False)
 # VirtualMuxes can be made generic
 from typing import Literal
 
-# the type keyword can be used to create reusable definitions
-# otherwise Literal can be used directly
-type Signals = Literal["signal_1", "signal_2"]
-
 # note: the type keyword can't be used inside functions!
 # generally we want to use type to avoid confusion around the type system
 # this makes it clear we are creating something for typehinting
 # e.g type MyInt = int - won't work in functions
 # variable = int - is not obvious what the intent is and can behave differently depending on its scope
 
+# the type keyword can be used to create reusable definitions
+# otherwise Literal can be used directly
+type MyTypedMuxSignals = Literal["signal_1", "signal_2"]
+
 
 def do_some_stuff():
     # otherwise the mux is created as normal
-    class MyTypedMux(VirtualMux[Signals]):
+    class MyTypedMux(VirtualMux[MyTypedMuxSignals]):
         pin_list = ("x0", "x1")
         map_list = (
             ("signal_1", "x0"),
@@ -98,7 +98,31 @@ def do_some_stuff():
     except ValueError as e:
         print(e)
 
-    class MyTypedRelay(RelayMatrixMux[Signals]):
+    # the annotations can also be used directly with Literal
+    class MyDirectlyTypedMux(VirtualMux[Literal["Sig_1", "Sig_2"]]):
+        pin_list = ("x0", "x1")
+        # Note this currently doesn't point out the incorrect signal mapping below!
+        # it is still up to the user to set up muxes correctly
+        map_list = (
+            ("signal_1", "x0"),
+            ("signal_2", "x1"),
+        )
+
+    # suggestions will work as normal
+    myothermux = MyDirectlyTypedMux()
+
+    myothermux.multiplex("")
+    myothermux.multiplex("Sig_1")
+    myothermux.multiplex("Sig_2")
+
+    try:
+        myothermux.multiplex("not_a_signal")
+    except ValueError as e:
+        print(e)
+
+    # general subclasses and RelayMatrixMux also work with this
+    # currently VirtualSwitch doesn't, it creates its own signal names doesn't really benefit from this
+    class MyTypedRelay(RelayMatrixMux[MyTypedMuxSignals]):
         pin_list = ("x3", "x4")
         map_list = (
             ("signal_1", "x3"),

--- a/examples/jig_driver.py
+++ b/examples/jig_driver.py
@@ -101,7 +101,7 @@ def do_some_stuff():
     # the annotations can also be used directly with Literal
     class MyDirectlyTypedMux(VirtualMux[Literal["Sig_1", "Sig_2"]]):
         pin_list = ("x0", "x1")
-        # Note this currently doesn't point out the incorrect signal mapping below!
+        # Note neither definition currently point out the incorrect signal mapping below!
         # it is still up to the user to set up muxes correctly
         map_list = (
             ("signal_1", "x0"),

--- a/examples/jig_driver.py
+++ b/examples/jig_driver.py
@@ -11,6 +11,7 @@ from fixate import (
     MuxGroup,
     PinValueAddressHandler,
     VirtualSwitch,
+    RelayMatrixMux,
 )
 
 
@@ -59,3 +60,55 @@ jig.mux.mux_one("sig2", trigger_update=False)
 jig.mux.mux_two("sig5")
 jig.mux.mux_three("On")
 jig.mux.mux_three(False)
+
+
+# VirtualMuxes can be made generic
+from typing import Literal
+
+# the type keyword can be used to create reusable definitions
+# otherwise Literal can be used directly
+type Signals = Literal["signal_1", "signal_2"]
+
+# note: the type keyword can't be used inside functions!
+# generally we want to use type to avoid confusion around the type system
+# this makes it clear we are creating something for typehinting
+# e.g type MyInt = int - won't work in functions
+# variable = int - is not obvious what the intent is and can behave differently depending on its scope
+
+
+def do_some_stuff():
+    # otherwise the mux is created as normal
+    class MyTypedMux(VirtualMux[Signals]):
+        pin_list = ("x0", "x1")
+        map_list = (
+            ("signal_1", "x0"),
+            ("signal_2", "x1"),
+        )
+
+    mymux = MyTypedMux()
+
+    # signal names will appear in the autocompletion options (including the empty signal "")
+    mymux.multiplex("")
+    mymux.multiplex("signal_1")
+    mymux.multiplex("signal_2")
+
+    # anything that isn't a signal will be flagged
+    try:
+        mymux.multiplex("not_a_signal")
+    except ValueError as e:
+        print(e)
+
+    class MyTypedRelay(RelayMatrixMux[Signals]):
+        pin_list = ("x3", "x4")
+        map_list = (
+            ("signal_1", "x3"),
+            ("signal_2", "x4"),
+        )
+
+    myrelay = MyTypedRelay()
+    myrelay.multiplex("")
+    myrelay.multiplex("signal_1")
+    myrelay.multiplex("signal_2")
+
+
+do_some_stuff()

--- a/examples/jig_driver.py
+++ b/examples/jig_driver.py
@@ -112,13 +112,23 @@ def do_some_stuff():
     myothermux = MyDirectlyTypedMux()
 
     myothermux.multiplex("")
-    myothermux.multiplex("Sig_1")
-    myothermux.multiplex("Sig_2")
+    # the suggested signal names will match the supplied names, but will cause exceptions
+    try:
+        myothermux.multiplex("Sig_1")
+    except ValueError as e:
+        print(e)
+    try:
+        myothermux.multiplex("Sig_2")
+    except ValueError as e:
+        print(e)
 
     try:
         myothermux.multiplex("not_a_signal")
     except ValueError as e:
         print(e)
+    # the real signal names will work, but type checkers will complain they are incorrect!
+    myothermux.multiplex("signal_1")
+    myothermux.multiplex("signal_2")
 
     # general subclasses and RelayMatrixMux also work with this
     # currently VirtualSwitch doesn't, it creates its own signal names doesn't really benefit from this

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -33,7 +33,6 @@ import itertools
 import time
 from typing import (
     Generic,
-    Optional,
     Callable,
     Sequence,
     TypeVar,
@@ -58,6 +57,7 @@ type PinList = Sequence[Pin]
 type PinSet = FrozenSet[Pin]
 type SignalMap[S: Signal] = Dict[S, PinSet]
 type TreeDef[S: Signal] = Sequence[S | "TreeDef"]
+type PinUpdateCallback = Callable[[PinUpdate, bool], None]
 
 
 def is_Signal(obj: Any) -> TypeGuard[Signal]:
@@ -97,9 +97,6 @@ class PinUpdate:
         return NotImplemented
 
 
-PinUpdateCallback = Callable[[PinUpdate, bool], None]
-
-
 class VirtualMux[S: Signal]:
     # define the union of what the user supplied and the automatically created
     # signal here so we don't have to keep typing this union everywhere
@@ -109,7 +106,7 @@ class VirtualMux[S: Signal]:
     ###########################################################################
     # These methods are the public API for the class
 
-    def __init__(self, update_pins: Optional[PinUpdateCallback] = None):
+    def __init__(self, update_pins: PinUpdateCallback | None = None):
         self._last_update_time = time.monotonic()
 
         self._update_pins: PinUpdateCallback
@@ -487,7 +484,7 @@ class VirtualSwitch(VirtualMux):
 
     def __init__(
         self,
-        update_pins: Optional[PinUpdateCallback] = None,
+        update_pins: PinUpdateCallback | None = None,
     ):
         if not self.pin_list:
             self.pin_list = [self.pin_name]

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -47,13 +47,13 @@ from operator import or_
 
 type Signal = str
 type EmptySignal = Literal[""]
-type MuxSignal[M: Signal = Signal] = M | EmptySignal
 type Pin = str
 type PinList = Sequence[Pin]
 type PinSet = frozenset[Pin]
-type SignalMap[S: Signal = Signal] = dict[S, PinSet]
-type TreeDef[S: Signal = Signal] = Sequence[S | "TreeDef"]
 type PinUpdateCallback = Callable[[PinUpdate, bool], None]
+type MuxSignal[M: Signal] = M | EmptySignal
+type SignalMap[S: Signal] = dict[S, PinSet]
+type TreeDef[S: Signal] = Sequence[S | "TreeDef"]
 
 
 @dataclass(frozen=True)

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -56,14 +56,6 @@ type TreeDef[S: Signal = Signal] = Sequence[S | "TreeDef"]
 type PinUpdateCallback = Callable[[PinUpdate, bool], None]
 
 
-def is_Signal(obj: Any) -> TypeGuard[Signal]:
-    """
-    like isinstance but using types
-    """
-    # in python 3.14 this can be updated to use .evaluate_value()
-    return isinstance(obj, Signal.__value__)
-
-
 @dataclass(frozen=True)
 class PinSetState:
     off: PinSet = frozenset()
@@ -101,6 +93,13 @@ class VirtualMux[S: Signal]:
 
     ###########################################################################
     # These methods are the public API for the class
+
+    def isSignal(self, obj: Any) -> TypeGuard[S]:
+        # we can tell the typechecker about our user specified signals here
+        # at runtime we just check if this is a string
+        # in the future S can be inspected using get_origin, get_args
+        # resolve_bases and get_original_bases
+        return isinstance(obj, Signal.__value__)
 
     def __init__(self, update_pins: PinUpdateCallback | None = None):
         self._last_update_time = time.monotonic()
@@ -408,7 +407,7 @@ class VirtualMux[S: Signal]:
             mux_b = TreeMap(("a1_b0", "a1_b1", "a1_b2", None), ("x2", "x3"))
             map_tree = TreeMap(("a0", mux_b, "a2", mux_c), ("x1", "x0"))
         """
-        signal_map: SignalMap = dict()
+        signal_map: SignalMap[MuxSignal[S]] = dict()
 
         bits_at_this_level = (len(tree) - 1).bit_length()
         pins_at_this_level = pins[:bits_at_this_level]
@@ -418,7 +417,7 @@ class VirtualMux[S: Signal]:
         ):
             if signal_or_tree is None:
                 continue
-            if is_Signal(signal_or_tree):
+            if self.isSignal(signal_or_tree):
                 signal_map[signal_or_tree] = frozenset(pins_for_signal) | fixed_pins
             else:
                 signal_map.update(

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -43,17 +43,29 @@ from typing import (
     Dict,
     FrozenSet,
     Iterable,
+    TypeGuard,
+    Any,
+    Literal,
 )
 from dataclasses import dataclass
 from functools import reduce
 from operator import or_
 
 type Signal = str
+type EmptySignal = Literal[""]
 type Pin = str
 type PinList = Sequence[Pin]
 type PinSet = FrozenSet[Pin]
 type SignalMap = Dict[Signal, PinSet]
 type TreeDef = Sequence[Union[Signal, "TreeDef"]]
+
+
+def is_Signal(obj: Any) -> TypeGuard[Signal]:
+    """
+    like isinstance but using types
+    """
+    # in python 3.14 this can be updated to use .evaluate_value()
+    return isinstance(obj, Signal.__value__)
 
 
 @dataclass(frozen=True)
@@ -88,7 +100,10 @@ class PinUpdate:
 PinUpdateCallback = Callable[[PinUpdate, bool], None]
 
 
-class VirtualMux:
+class VirtualMux[S: Signal]:
+    # define the union of what the user supplied and the automatically created
+    # signal here so we don't have to keep typing this union everywhere
+    type MuxSignal = S | EmptySignal
     pin_list: PinList = ()
     clearing_time: float = 0.0
 
@@ -129,7 +144,7 @@ class VirtualMux:
         if hasattr(self, "default_signal"):
             raise ValueError("'default_signal' should not be set on a VirtualMux")
 
-    def __call__(self, signal: Signal, trigger_update: bool = True) -> None:
+    def __call__(self, signal: MuxSignal, trigger_update: bool = True) -> None:
         """
         Convenience to avoid having to type jig.mux.<MuxName>.multiplex.
 
@@ -138,7 +153,7 @@ class VirtualMux:
         """
         self.multiplex(signal, trigger_update)
 
-    def multiplex(self, signal: Signal, trigger_update: bool = True) -> None:
+    def multiplex(self, signal: MuxSignal, trigger_update: bool = True) -> None:
         """
         Update the multiplexer state to signal.
 
@@ -163,7 +178,7 @@ class VirtualMux:
             self._last_update_time = time.monotonic()
         self._state = signal
 
-    def all_signals(self) -> tuple[Signal, ...]:
+    def all_signals(self) -> tuple[MuxSignal, ...]:
         return tuple(self._signal_map.keys())
 
     def reset(self, trigger_update: bool = True) -> None:
@@ -191,7 +206,7 @@ class VirtualMux:
     # The following methods are potential candidates to override in a subclass
 
     def _calculate_pins(
-        self, old_signal: Signal, new_signal: Signal
+        self, old_signal: MuxSignal, new_signal: MuxSignal
     ) -> tuple[PinSetState, PinSetState]:
         """
         Calculate the pin sets for the two-step state change.
@@ -409,7 +424,7 @@ class VirtualMux:
         ):
             if signal_or_tree is None:
                 continue
-            if isinstance(signal_or_tree, Signal):
+            if is_Signal(signal_or_tree):
                 signal_map[signal_or_tree] = frozenset(pins_for_signal) | fixed_pins
             else:
                 signal_map.update(
@@ -482,7 +497,7 @@ class VirtualSwitch(VirtualMux):
         super().__init__(update_pins)
 
 
-class RelayMatrixMux(VirtualMux):
+class RelayMatrixMux[S: Signal](VirtualMux[S]):
     clearing_time = 0.01
 
     def _calculate_pins(

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -56,8 +56,8 @@ type EmptySignal = Literal[""]
 type Pin = str
 type PinList = Sequence[Pin]
 type PinSet = FrozenSet[Pin]
-type SignalMap = Dict[Signal, PinSet]
-type TreeDef = Sequence[Union[Signal, "TreeDef"]]
+type SignalMap[S: Signal] = Dict[S, PinSet]
+type TreeDef[S: Signal] = Sequence[Union[S, "TreeDef"]]
 
 
 def is_Signal(obj: Any) -> TypeGuard[Signal]:
@@ -103,7 +103,7 @@ PinUpdateCallback = Callable[[PinUpdate, bool], None]
 class VirtualMux[S: Signal]:
     # define the union of what the user supplied and the automatically created
     # signal here so we don't have to keep typing this union everywhere
-    type MuxSignal = S | EmptySignal
+    type MuxSignal[M: Signal] = M | EmptySignal
     pin_list: PinList = ()
     clearing_time: float = 0.0
 
@@ -125,9 +125,9 @@ class VirtualMux[S: Signal]:
         # we convert here and keep a reference to the set for future use.
         self._pin_set = frozenset(self.pin_list)
 
-        self._state = ""
+        self._state: VirtualMux.MuxSignal[S] = ""
 
-        self._signal_map: SignalMap = self._map_signals()
+        self._signal_map: SignalMap[VirtualMux.MuxSignal[S]] = self._map_signals()
 
         # Define the implicit signal "" which can be used to turn off all pins.
         # If the signal map already has this defined, raise an error. In the old
@@ -144,7 +144,7 @@ class VirtualMux[S: Signal]:
         if hasattr(self, "default_signal"):
             raise ValueError("'default_signal' should not be set on a VirtualMux")
 
-    def __call__(self, signal: MuxSignal, trigger_update: bool = True) -> None:
+    def __call__(self, signal: MuxSignal[S], trigger_update: bool = True) -> None:
         """
         Convenience to avoid having to type jig.mux.<MuxName>.multiplex.
 
@@ -153,7 +153,7 @@ class VirtualMux[S: Signal]:
         """
         self.multiplex(signal, trigger_update)
 
-    def multiplex(self, signal: MuxSignal, trigger_update: bool = True) -> None:
+    def multiplex(self, signal: MuxSignal[S], trigger_update: bool = True) -> None:
         """
         Update the multiplexer state to signal.
 
@@ -178,7 +178,7 @@ class VirtualMux[S: Signal]:
             self._last_update_time = time.monotonic()
         self._state = signal
 
-    def all_signals(self) -> tuple[MuxSignal, ...]:
+    def all_signals(self) -> tuple[MuxSignal[S], ...]:
         return tuple(self._signal_map.keys())
 
     def reset(self, trigger_update: bool = True) -> None:
@@ -206,7 +206,7 @@ class VirtualMux[S: Signal]:
     # The following methods are potential candidates to override in a subclass
 
     def _calculate_pins(
-        self, old_signal: MuxSignal, new_signal: MuxSignal
+        self, old_signal: MuxSignal[S], new_signal: MuxSignal[S]
     ) -> tuple[PinSetState, PinSetState]:
         """
         Calculate the pin sets for the two-step state change.
@@ -233,7 +233,7 @@ class VirtualMux[S: Signal]:
     # The following methods are intended as implementation detail and
     # subclasses should avoid overriding.
 
-    def _map_signals(self) -> SignalMap:
+    def _map_signals(self) -> SignalMap[VirtualMux.MuxSignal[S]]:
         """
         Default implementation of the signal mapping
 
@@ -254,7 +254,9 @@ class VirtualMux[S: Signal]:
                 "VirtualMux subclass must define either map_tree or map_list"
             )
 
-    def _map_tree(self, tree: TreeDef, pins: PinList, fixed_pins: PinSet) -> SignalMap:
+    def _map_tree(
+        self, tree: TreeDef[S], pins: PinList, fixed_pins: PinSet
+    ) -> SignalMap[VirtualMux.MuxSignal[S]]:
         """recursively add nested signal lists to the signal map.
         tree: is the current sub-branch to be added. At the first call
         level, this would be initialised with self.map_tree. It can be
@@ -501,7 +503,7 @@ class RelayMatrixMux[S: Signal](VirtualMux[S]):
     clearing_time = 0.01
 
     def _calculate_pins(
-        self, old_signal: Signal, new_signal: Signal
+        self, old_signal: VirtualMux.MuxSignal[S], new_signal: VirtualMux.MuxSignal[S]
     ) -> tuple[PinSetState, PinSetState]:
         """
         Override of _calculate_pins to implement break-before-make switching.

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 import itertools
 import time
 from typing import (
-    Generic,
     Callable,
     Sequence,
     TypeVar,
@@ -693,10 +692,7 @@ class MuxGroup:
         return [str(mux) for mux in self.get_multiplexers()]
 
 
-JigSpecificMuxGroup = TypeVar("JigSpecificMuxGroup", bound=MuxGroup)
-
-
-class JigDriver(Generic[JigSpecificMuxGroup]):
+class JigDriver[M: MuxGroup]():
     """
     Combine multiple VirtualMux's and multiple AddressHandler's.
 
@@ -705,7 +701,7 @@ class JigDriver(Generic[JigSpecificMuxGroup]):
 
     def __init__(
         self,
-        mux_group_factory: Callable[[], JigSpecificMuxGroup],
+        mux_group_factory: Callable[[], M],
         handlers: Sequence[AddressHandler],
     ):
         # keep a reference to handlers so that we can close them if required.

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -34,11 +34,8 @@ import time
 from typing import (
     Callable,
     Sequence,
-    TypeVar,
     Generator,
     Collection,
-    Dict,
-    FrozenSet,
     Iterable,
     TypeGuard,
     Any,
@@ -53,8 +50,8 @@ type EmptySignal = Literal[""]
 type MuxSignal[M: Signal] = M | EmptySignal
 type Pin = str
 type PinList = Sequence[Pin]
-type PinSet = FrozenSet[Pin]
-type SignalMap[S: Signal] = Dict[S, PinSet]
+type PinSet = frozenset[Pin]
+type SignalMap[S: Signal] = dict[S, PinSet]
 type TreeDef[S: Signal] = Sequence[S | "TreeDef"]
 type PinUpdateCallback = Callable[[PinUpdate, bool], None]
 
@@ -779,10 +776,7 @@ class JigDriver[M: MuxGroup]():
             )
 
 
-_T = TypeVar("_T")
-
-
-def _generate_bit_sets(bits: Sequence[_T]) -> Generator[set[_T], None, None]:
+def _generate_bit_sets[_T](bits: Sequence[_T]) -> Generator[set[_T], None, None]:
     """
     Create subsets of bits, representing bits of a list of integers
 

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -38,7 +38,6 @@ from typing import (
     Sequence,
     TypeVar,
     Generator,
-    Union,
     Collection,
     Dict,
     FrozenSet,
@@ -58,7 +57,7 @@ type Pin = str
 type PinList = Sequence[Pin]
 type PinSet = FrozenSet[Pin]
 type SignalMap[S: Signal] = Dict[S, PinSet]
-type TreeDef[S: Signal] = Sequence[Union[S, "TreeDef"]]
+type TreeDef[S: Signal] = Sequence[S | "TreeDef"]
 
 
 def is_Signal(obj: Any) -> TypeGuard[Signal]:
@@ -473,9 +472,7 @@ class VirtualSwitch(VirtualMux):
     pin_name: Pin = ""
     map_tree = ("Off", "On")
 
-    def multiplex(
-        self, signal: Union[Signal, bool], trigger_update: bool = True
-    ) -> None:
+    def multiplex(self, signal: Signal | bool, trigger_update: bool = True) -> None:
         if signal is True:
             converted_signal = "On"
         elif signal is False:
@@ -484,9 +481,7 @@ class VirtualSwitch(VirtualMux):
             converted_signal = signal
         super().multiplex(converted_signal, trigger_update=trigger_update)
 
-    def __call__(
-        self, signal: Union[Signal, bool], trigger_update: bool = True
-    ) -> None:
+    def __call__(self, signal: Signal | bool, trigger_update: bool = True) -> None:
         """Override call to set the type on signal_output correctly."""
         self.multiplex(signal, trigger_update)
 

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -48,12 +48,12 @@ from dataclasses import dataclass
 from functools import reduce
 from operator import or_
 
-Signal = str
-Pin = str
-PinList = Sequence[Pin]
-PinSet = FrozenSet[Pin]
-SignalMap = Dict[Signal, PinSet]
-TreeDef = Sequence[Union[Signal, "TreeDef"]]
+type Signal = str
+type Pin = str
+type PinList = Sequence[Pin]
+type PinSet = FrozenSet[Pin]
+type SignalMap = Dict[Signal, PinSet]
+type TreeDef = Sequence[Union[Signal, "TreeDef"]]
 
 
 @dataclass(frozen=True)

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -47,12 +47,12 @@ from operator import or_
 
 type Signal = str
 type EmptySignal = Literal[""]
-type MuxSignal[M: Signal] = M | EmptySignal
+type MuxSignal[M: Signal = Signal] = M | EmptySignal
 type Pin = str
 type PinList = Sequence[Pin]
 type PinSet = frozenset[Pin]
-type SignalMap[S: Signal] = dict[S, PinSet]
-type TreeDef[S: Signal] = Sequence[S | "TreeDef"]
+type SignalMap[S: Signal = Signal] = dict[S, PinSet]
+type TreeDef[S: Signal = Signal] = Sequence[S | "TreeDef"]
 type PinUpdateCallback = Callable[[PinUpdate, bool], None]
 
 

--- a/src/fixate/_switching.py
+++ b/src/fixate/_switching.py
@@ -53,6 +53,7 @@ from operator import or_
 
 type Signal = str
 type EmptySignal = Literal[""]
+type MuxSignal[M: Signal] = M | EmptySignal
 type Pin = str
 type PinList = Sequence[Pin]
 type PinSet = FrozenSet[Pin]
@@ -103,7 +104,6 @@ PinUpdateCallback = Callable[[PinUpdate, bool], None]
 class VirtualMux[S: Signal]:
     # define the union of what the user supplied and the automatically created
     # signal here so we don't have to keep typing this union everywhere
-    type MuxSignal[M: Signal] = M | EmptySignal
     pin_list: PinList = ()
     clearing_time: float = 0.0
 
@@ -125,9 +125,9 @@ class VirtualMux[S: Signal]:
         # we convert here and keep a reference to the set for future use.
         self._pin_set = frozenset(self.pin_list)
 
-        self._state: VirtualMux.MuxSignal[S] = ""
+        self._state: MuxSignal[S] = ""
 
-        self._signal_map: SignalMap[VirtualMux.MuxSignal[S]] = self._map_signals()
+        self._signal_map: SignalMap[MuxSignal[S]] = self._map_signals()
 
         # Define the implicit signal "" which can be used to turn off all pins.
         # If the signal map already has this defined, raise an error. In the old
@@ -233,7 +233,7 @@ class VirtualMux[S: Signal]:
     # The following methods are intended as implementation detail and
     # subclasses should avoid overriding.
 
-    def _map_signals(self) -> SignalMap[VirtualMux.MuxSignal[S]]:
+    def _map_signals(self) -> SignalMap[MuxSignal[S]]:
         """
         Default implementation of the signal mapping
 
@@ -256,7 +256,7 @@ class VirtualMux[S: Signal]:
 
     def _map_tree(
         self, tree: TreeDef[S], pins: PinList, fixed_pins: PinSet
-    ) -> SignalMap[VirtualMux.MuxSignal[S]]:
+    ) -> SignalMap[MuxSignal[S]]:
         """recursively add nested signal lists to the signal map.
         tree: is the current sub-branch to be added. At the first call
         level, this would be initialised with self.map_tree. It can be
@@ -503,7 +503,7 @@ class RelayMatrixMux[S: Signal](VirtualMux[S]):
     clearing_time = 0.01
 
     def _calculate_pins(
-        self, old_signal: VirtualMux.MuxSignal[S], new_signal: VirtualMux.MuxSignal[S]
+        self, old_signal: MuxSignal[S], new_signal: MuxSignal[S]
     ) -> tuple[PinSetState, PinSetState]:
         """
         Override of _calculate_pins to implement break-before-make switching.

--- a/test/test_switching.py
+++ b/test/test_switching.py
@@ -336,6 +336,26 @@ def test_virtual_mux_basic_typed():
     ]
 
 
+@pytest.mark.xfail(reason="Signal narrowowing not implemented")
+def test_virtual_mux_typed_isSignal():
+    mux_a = MuxATyped()
+
+    assert mux_a.isSignal("sig_a1")  # should pass
+    assert not mux_a.isSignal("")  # this shouldn't be supplied by the user
+    assert not mux_a.isSignal(1)  # wrong type
+    assert not mux_a.isSignal("1")  # not a signal for MuxATyped - not yet implemented
+
+
+def test_virtual_mux_isSignal():
+    mux_a = MuxA()
+    # this mux isn't type, so anything that is a string should pass this
+    # to check we don't accidentally break untyped muxes in the future
+    assert mux_a.isSignal("sig_a1")  # should pass
+    assert mux_a.isSignal("")  # should pass
+    assert not mux_a.isSignal(1)  # wrong type
+    assert mux_a.isSignal("1")  # should pass
+
+
 def test_virtual_mux_reset():
     """Check that reset sends an update that sets all pins off"""
 

--- a/test/test_switching.py
+++ b/test/test_switching.py
@@ -1,4 +1,4 @@
-from typing import Collection, Sequence
+from typing import Collection, Sequence, Literal
 
 from fixate._switching import (
     Pin,
@@ -289,9 +289,36 @@ class MuxA(VirtualMux):
     map_list = (("sig_a1", "a0", "a1"), ("sig_a2", "a1"))
 
 
+class MuxATyped(VirtualMux[Literal["sig_a1", "sig_a2"]]):
+    """A mux definition used by a few tests"""
+
+    pin_list = ("a0", "a1")
+    map_list = (("sig_a1", "a0", "a1"), ("sig_a2", "a1"))
+
+
 def test_virtual_mux_basic():
     updates = []
     mux_a = MuxA(lambda x, y: updates.append((x, y)))
+
+    # test both the __call__ and multiplex methods trigger
+    # the appropriate update callback.
+    mux_a("sig_a1")
+    mux_a.multiplex("sig_a2", trigger_update=False)
+    mux_a("")
+
+    clear = PinSetState(off=frozenset({"a0", "a1"}))
+    a1 = PinSetState(on=frozenset({"a0", "a1"}))
+    a2 = PinSetState(on=frozenset({"a1"}), off=frozenset({"a0"}))
+    assert updates == [
+        (PinUpdate(PinSetState(), a1), True),
+        (PinUpdate(PinSetState(), a2), False),
+        (PinUpdate(PinSetState(), clear), True),
+    ]
+
+
+def test_virtual_mux_basic_typed():
+    updates = []
+    mux_a = MuxATyped(lambda x, y: updates.append((x, y)))
 
     # test both the __call__ and multiplex methods trigger
     # the appropriate update callback.


### PR DESCRIPTION
I like this approach more than https://github.com/PyFixate/Fixate/pull/188
Annotated never felt quite right. I'm going to go ahead with the approach of making the user still have to define the mapping between signals and pins themselves. Having to chain Union and Literal together also was clunky as Literal is already kind of like a union of options.

In the future this will be easier to add features to, e.g pin typing, and hinting for constructing the map or tree.
The type hints can also eventually be digested to not have to repeat the pin list.
